### PR TITLE
hide the navigation menu on small screens as default

### DIFF
--- a/dfgviewer/res/js/script.js
+++ b/dfgviewer/res/js/script.js
@@ -32,7 +32,14 @@ $(document).ready(function() {
 	// show/hide navigation (with cookie-saved status)
 	$('.tx-dlf-toc').append('<div class="hideNav" title="Navigation ein- und ausblenden"></div>');
 	var navigationStatus = getCookie('dfgviewer-navigationStatus');
-	if(navigationStatus == "closed") { $('#navcontainer').hide(); $('.tx-dlf-toc').css({'width':'30px'}); $('#whiteboxcontainer').css({'right':'30px'}); $('.hideNav').addClass('hiddenNav'); }
+	// hide navigation if cookie set to closed OR on small windows as default
+	if(navigationStatus == "closed" || (!navigationStatus && $('#whiteboxcontainer').outerWidth() < 700)) {
+		$('#navcontainer').hide();
+		$('.tx-dlf-toc').css({'width':'30px'});
+		$('#whiteboxcontainer').css({'right':'30px'});
+		$('.hideNav').addClass('hiddenNav');
+	}
+
 	$('.hideNav').click(function() {
 		if($(this).hasClass('hiddenNav')) {
 			$('.tx-dlf-toc').css({'width':'300px'});


### PR DESCRIPTION
The navigation menu is about 300px wide and is shown as default. The user may hide it by click on the arrow on the right. This state is saved in a cookie too for further usage.

The patch changes the behaviour on narrow width screens. The menu is hidden as long the user click on the arrow to open it. This state is saved in a cookie too for further usage.
