### PR TITLE
Fixes for newspaper metadata handling

### DIFF
--- a/dfgviewer/modules/setup/locallang.xml
+++ b/dfgviewer/modules/setup/locallang.xml
@@ -98,6 +98,7 @@
 			<label index="leavesCount">Leaves Count</label>
 			<label index="place">Place of Publication</label>
 			<label index="parentPlace">Place of Publication (Parent)</label>
+			<label index="publicationRun">Publication Run</label>
 			<label index="year">Year of Publication</label>
 			<label index="parentYear">Year of Publication (Parent)</label>
 			<label index="vd16">VD16</label>
@@ -196,6 +197,7 @@
 			<label index="leavesCount">Blattzahl</label>
 			<label index="place">Erscheinungsort</label>
 			<label index="parentPlace">Erscheinungsort (Gesamtheit)</label>
+			<label index="publicationRun">Erscheinungsverlauf</label>
 			<label index="year">Erscheinungsjahr</label>
 			<label index="parentYear">Erscheinungsjahr (Gesamtheit)</label>
 			<label index="vd16">VD16</label>

--- a/dfgviewer/modules/setup/locallang.xml
+++ b/dfgviewer/modules/setup/locallang.xml
@@ -94,6 +94,7 @@
 			<label index="title">Title</label>
 			<label index="parentTitle">Parent Title</label>
 			<label index="volume">Volume</label>
+			<label index="issue">Issue</label>
 			<label index="material">Material</label>
 			<label index="leavesCount">Leaves Count</label>
 			<label index="place">Place of Publication</label>
@@ -193,6 +194,7 @@
 			<label index="title">Titel</label>
 			<label index="parentTitle">Gesamttitel</label>
 			<label index="volume">Band</label>
+			<label index="issue">Ausgabe</label>
 			<label index="material">Beschreibstoff</label>
 			<label index="leavesCount">Blattzahl</label>
 			<label index="place">Erscheinungsort</label>

--- a/dfgviewer/modules/setup/locallang.xml
+++ b/dfgviewer/modules/setup/locallang.xml
@@ -151,7 +151,7 @@
 			<label index="imprint">Impressum</label>
 			<label index="index">Register</label>
 			<label index="initial_decoration">Initialschmuck</label>
-			<label index="issue">Heft</label>
+			<label index="issue">Ausgabe</label>
 			<label index="lecture">Vorlesung</label>
 			<label index="letter">Brief</label>
 			<label index="magister_thesis">Magisterarbeit</label>

--- a/dfgviewer/modules/setup/metadata.inc.php
+++ b/dfgviewer/modules/setup/metadata.inc.php
@@ -180,8 +180,21 @@ $metadata = array (
 		'wrap' => '',
 		'is_listed' => 0,
 	),
-	'year' => array (
+	'publicationRun' => array (
 		'hidden' => 0,
+		'format' => array (
+			array (
+				'encoded' => 1,
+				'xpath' => '',
+				'xpath_sorting' => '',
+			),
+		),
+		'default_value' => '',
+		'wrap' => "key.wrap = <span style=\"display:none;\">|: </span>\nvalue.ifBlank.field = year\nvalue.ifBlank.field = parentYear\nvalue.required = 1\nvalue.replacement.1.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/\nvalue.replacement.1.replace = $3.$2.$1\nvalue.replacement.1.useRegExp = 1\nvalue.noTrimWrap = ||, |\nall.substring = 0,-2\nall.noTrimWrap = |<span class=\"date\">|</span> |",
+		'is_listed' => 1,
+	),
+	'year' => array (
+		'hidden' => 1,
 		'format' => array (
 			array (
 				'encoded' => 2,
@@ -190,8 +203,8 @@ $metadata = array (
 			),
 		),
 		'default_value' => '',
-		'wrap' => "key.wrap = <span style=\"display:none;\">|: </span>\nvalue.ifEmpty.field = parentYear\nvalue.required = 1\nvalue.noTrimWrap = ||, |\nall.substring = 0,-2\nall.noTrimWrap = |<span class=\"date\">|</span> |",
-		'is_listed' => 1,
+		'wrap' => '',
+		'is_listed' => 0,
 	),
 	'parentYear' => array (
 		'hidden' => 1,

--- a/dfgviewer/modules/setup/metadata.inc.php
+++ b/dfgviewer/modules/setup/metadata.inc.php
@@ -185,12 +185,12 @@ $metadata = array (
 		'format' => array (
 			array (
 				'encoded' => 1,
-				'xpath' => '',
+				'xpath' => 'concat(./mods:originInfo[not(./mods:edition="[Electronic ed.]")]/mods:dateIssued[@point="start"]," - ",./mods:originInfo[not(./mods:edition="[Electronic ed.]")]/mods:dateIssued[@point="end"])',
 				'xpath_sorting' => '',
 			),
 		),
 		'default_value' => '',
-		'wrap' => "key.wrap = <span style=\"display:none;\">|: </span>\nvalue.ifBlank.field = year\nvalue.ifBlank.field = parentYear\nvalue.required = 1\nvalue.replacement.1.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/\nvalue.replacement.1.replace = $3.$2.$1\nvalue.replacement.1.useRegExp = 1\nvalue.noTrimWrap = ||, |\nall.substring = 0,-2\nall.noTrimWrap = |<span class=\"date\">|</span> |",
+		'wrap' => "key.wrap = <span style=\"display:none;\">|: </span>\nvalue.replacement.1.search = /^-$/\nvalue.replacement.1.replace.field = year // parentYear\nvalue.replacement.1.useRegExp = 1\nvalue.replacement.2.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/\nvalue.replacement.2.replace = $3.$2.$1\nvalue.replacement.2.useRegExp = 1\nvalue.required = 1\nvalue.noTrimWrap = ||, |\nall.substring = 0,-2\nall.noTrimWrap = |<span class=\"date\">|</span> |",
 		'is_listed' => 1,
 	),
 	'year' => array (

--- a/dfgviewer/modules/setup/metadata.inc.php
+++ b/dfgviewer/modules/setup/metadata.inc.php
@@ -128,6 +128,19 @@ $metadata = array (
 		'wrap' => "key.noTrimWrap = || |\nvalue.if.value.field = type\nvalue.if.equals = volume\nvalue.required = 1\nall.noTrimWrap = |<span class=\"volume\">|</span> |",
 		'is_listed' => 1,
 	),
+	'issue' => array (
+		'hidden' => 0,
+		'format' => array (
+			array (
+				'encoded' => 1,
+				'xpath' => './mods:part/mods:detail/mods:number',
+				'xpath_sorting' => './mods:part[@type="host"]/@order',
+			),
+		),
+		'default_value' => '',
+		'wrap' => "key.noTrimWrap = || |\nvalue.if.value.field = type\nvalue.if.equals = issue\nvalue.required = 1\nall.noTrimWrap = |<span class=\"volume\">|</span> |",
+		'is_listed' => 1,
+	),
 	'material' => array (
 		'hidden' => 0,
 		'format' => array (

--- a/dfgviewer/modules/setup/metadata.inc.php
+++ b/dfgviewer/modules/setup/metadata.inc.php
@@ -99,7 +99,7 @@ $metadata = array (
 			),
 		),
 		'default_value' => '',
-		'wrap' => "key.wrap = <span style=\"display:none;\">|: </span>\nvalue.ifEmpty.field = parentTitle\nvalue.required = 1\nall.noTrimWrap = |<h2>|</h2> |",
+		'wrap' => "key.wrap = <span style=\"display:none;\">|: </span>\nvalue.ifEmpty.field = parentTitle\nvalue.ifEmpty.wrap = [|]\nvalue.required = 1\nall.noTrimWrap = |<h2>|</h2> |",
 		'is_listed' => 1,
 	),
 	'parentTitle' => array (
@@ -125,7 +125,7 @@ $metadata = array (
 			),
 		),
 		'default_value' => '',
-		'wrap' => "key.noTrimWrap = || |\nvalue.required = 1\nall.noTrimWrap = |<span class=\"volume\">|</span> |",
+		'wrap' => "key.noTrimWrap = || |\nvalue.if.value.field = type\nvalue.if.equals = volume\nvalue.required = 1\nall.noTrimWrap = |<span class=\"volume\">|</span> |",
 		'is_listed' => 1,
 	),
 	'material' => array (

--- a/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
+++ b/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
@@ -118,7 +118,15 @@ class tx_dfgviewer_uri extends tx_dlf_plugin {
 
 				} elseif (strpos($uri, 'urn:') === 0) {
 
-					$uris[] = '<a href="http://nbn-resolving.de/'.urlencode($uri).'">'.htmlspecialchars($uri).'</a>';
+					if (strpos($uri, '/fragment/') === FALSE) {
+
+						$uris[] = '<a href="http://nbn-resolving.de/' . urlencode($uri) . '">' . htmlspecialchars($uri) . '</a>';
+
+					} else {
+
+						$uris[] = '<a href="http://nbn-resolving.org/' . urlencode($uri) . '">' . htmlspecialchars($uri) . '</a>';
+
+					}
 
 				}
 
@@ -147,7 +155,15 @@ class tx_dfgviewer_uri extends tx_dlf_plugin {
 
 				} elseif (strpos($uri, 'urn:') === 0) {
 
-					$uris[] = '<a href="http://nbn-resolving.de/'.htmlspecialchars($uri).'">'.htmlspecialchars($uri).'</a>';
+					if (strpos($uri, '/fragment/') === FALSE) {
+
+						$uris[] = '<a href="http://nbn-resolving.de/' . urlencode($uri) . '">' . htmlspecialchars($uri) . '</a>';
+
+					} else {
+
+						$uris[] = '<a href="http://nbn-resolving.org/' . urlencode($uri) . '">' . htmlspecialchars($uri) . '</a>';
+
+					}
 
 				}
 


### PR DESCRIPTION
Includes:
- distinction between legacy and granular URN
- display of publication run (fallback: publication date)
- reformat dates from YYYY-MM-DD to DD.MM.YYYY
- show title of superior work if applicable