### PR TITLE
Replace deprecated classes according to changes in Goobi.Presentation

### DIFF
--- a/dfgviewer/ext_autoload.php
+++ b/dfgviewer/ext_autoload.php
@@ -30,5 +30,3 @@ return array (
 	'tx_dfgviewer_gridpager' => $extensionPath.'plugins/gridpager/class.tx_dfgviewer_gridpager.php',
 	'tx_dfgviewer_uri' => $extensionPath.'plugins/uri/class.tx_dfgviewer_uri.php'
 );
-
-?>

--- a/dfgviewer/ext_autoload.php
+++ b/dfgviewer/ext_autoload.php
@@ -22,7 +22,7 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-$extensionPath = t3lib_extMgm::extPath('dfgviewer');
+$extensionPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('dfgviewer');
 
 return array (
 	'tx_dfgviewer_modSetup' => $extensionPath.'modules/setup/index.php',

--- a/dfgviewer/ext_emconf.php
+++ b/dfgviewer/ext_emconf.php
@@ -53,5 +53,3 @@ $EM_CONF[$_EXTKEY] = array(
 	),
 	'_md5_values_when_last_written' => '',
 );
-
-?>

--- a/dfgviewer/ext_emconf.php
+++ b/dfgviewer/ext_emconf.php
@@ -42,9 +42,9 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '3.1.0',
 	'constraints' => array(
 		'depends' => array(
-			'php' => '5.3.0-',
-			'typo3' => '4.5.0-6.2.99',
-			'dlf' => '1.2.1-',
+			'php' => '5.4.0-',
+			'typo3' => '6.2.0-6.2.99',
+			'dlf' => '1.3.0-',
 		),
 		'conflicts' => array(
 		),

--- a/dfgviewer/ext_localconf.php
+++ b/dfgviewer/ext_localconf.php
@@ -25,17 +25,17 @@
 if (!defined ('TYPO3_MODE')) 	die ('Access denied.');
 
 // Register plugins.
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/amd/class.tx_dfgviewer_amd.php', '_amd', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/amd/class.tx_dfgviewer_amd.php', '_amd', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/gridpager/class.tx_dfgviewer_gridpager.php', '_gridpager', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/gridpager/class.tx_dfgviewer_gridpager.php', '_gridpager', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/uri/class.tx_dfgviewer_uri.php', '_uri', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/uri/class.tx_dfgviewer_uri.php', '_uri', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php', '_newspapercalendar', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php', '_newspapercalendar', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php', '_newspaperyears', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php', '_newspaperyears', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/sru/class.tx_dfgviewer_sru.php', '_sru', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/sru/class.tx_dfgviewer_sru.php', '_sru', 'list_type', TRUE);
 
 // Register eID handlers.
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dfgviewer_sru_eid'] = 'EXT:'.$_EXTKEY.'/plugins/sru/class.tx_dfgviewer_sru_eid.php';

--- a/dfgviewer/ext_localconf.php
+++ b/dfgviewer/ext_localconf.php
@@ -39,5 +39,3 @@ if (!defined ('TYPO3_MODE')) 	die ('Access denied.');
 
 // Register eID handlers.
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dfgviewer_sru_eid'] = 'EXT:'.$_EXTKEY.'/plugins/sru/class.tx_dfgviewer_sru_eid.php';
-
-?>

--- a/dfgviewer/ext_tables.php
+++ b/dfgviewer/ext_tables.php
@@ -28,7 +28,7 @@ if (!defined ('TYPO3_MODE')) die ('Access denied.');
 t3lib_extMgm::addStaticFile($_EXTKEY, 'typoscript/', 'DFG Viewer');
 
 // Register plugins.
-t3lib_div::loadTCA('tt_content');
+\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tt_content');
 
 // Plugin "amd".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_amd'] = 'layout,select_key,pages,recursive';

--- a/dfgviewer/ext_tables.php
+++ b/dfgviewer/ext_tables.php
@@ -25,7 +25,7 @@
 if (!defined ('TYPO3_MODE')) die ('Access denied.');
 
 // Register static typoscript.
-t3lib_extMgm::addStaticFile($_EXTKEY, 'typoscript/', 'DFG Viewer');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'typoscript/', 'DFG Viewer');
 
 // Register plugins.
 \TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tt_content');
@@ -35,35 +35,35 @@ $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_amd'] = '
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_amd'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dfgviewer/locallang.xml:tt_content.dfgviewer_amd', $_EXTKEY.'_amd'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dfgviewer/locallang.xml:tt_content.dfgviewer_amd', $_EXTKEY.'_amd'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_amd', 'FILE:EXT:'.$_EXTKEY.'/plugins/amd/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_amd', 'FILE:EXT:'.$_EXTKEY.'/plugins/amd/flexform.xml');
 
 // Plugin "gridpager".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_gridpager'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_gridpager'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dfgviewer/locallang.xml:tt_content.dfgviewer_gridpager', $_EXTKEY.'_gridpager'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dfgviewer/locallang.xml:tt_content.dfgviewer_gridpager', $_EXTKEY.'_gridpager'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_gridpager', 'FILE:EXT:'.$_EXTKEY.'/plugins/gridpager/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_gridpager', 'FILE:EXT:'.$_EXTKEY.'/plugins/gridpager/flexform.xml');
 
 // Plugin "uri".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_uri'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_uri'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dfgviewer/locallang.xml:tt_content.dfgviewer_uri', $_EXTKEY.'_uri'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dfgviewer/locallang.xml:tt_content.dfgviewer_uri', $_EXTKEY.'_uri'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_uri', 'FILE:EXT:'.$_EXTKEY.'/plugins/uri/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_uri', 'FILE:EXT:'.$_EXTKEY.'/plugins/uri/flexform.xml');
 
 // Register modules.
 if (TYPO3_MODE == 'BE')	{
 
 	// Module "setup".
-	t3lib_extMgm::addModule('txdlfmodules', 'txdfgviewersetup', '', t3lib_extMgm::extPath($_EXTKEY).'modules/setup/');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addModule('txdlfmodules', 'txdfgviewersetup', '', \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'modules/setup/');
 
-	t3lib_extMgm::addLLrefForTCAdescr('_MOD_txdlfmodules_txdfgviewersetup','EXT:dfgviewer/modules/setup/locallang_mod.xml');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('_MOD_txdlfmodules_txdfgviewersetup','EXT:dfgviewer/modules/setup/locallang_mod.xml');
 
 }
 

--- a/dfgviewer/ext_tables.php
+++ b/dfgviewer/ext_tables.php
@@ -66,5 +66,3 @@ if (TYPO3_MODE == 'BE')	{
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('_MOD_txdlfmodules_txdfgviewersetup','EXT:dfgviewer/modules/setup/locallang_mod.xml');
 
 }
-
-?>

--- a/dfgviewer/modules/setup/conf.php
+++ b/dfgviewer/modules/setup/conf.php
@@ -31,5 +31,3 @@ $MCONF['script'] = '_DISPATCH';
 $MLANG['default']['tabs_images']['tab'] = '../../res/icons/txdfgviewersetup.png';
 
 $MLANG['default']['ll_ref'] = 'LLL:EXT:dfgviewer/modules/setup/locallang_mod.xml';
-
-?>

--- a/dfgviewer/modules/setup/index.php
+++ b/dfgviewer/modules/setup/index.php
@@ -66,7 +66,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 		include_once(t3lib_extMgm::extPath($this->extKey).'modules/'.$this->modPath.'metadata.inc.php');
 
 		// Load table configuration array to get default field values.
-		t3lib_div::loadTCA('tx_dlf_metadata');
+		\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tx_dlf_metadata');
 
 		$i = 0;
 
@@ -115,7 +115,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 		if (count($_ids) == $i) {
 
 			// Fine.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.metadataAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.metadataAdded', TRUE),
@@ -126,7 +126,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 		} else {
 
 			// Something went wrong.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.metadataNotAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.metadataNotAdded', TRUE),
@@ -171,7 +171,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 		if (count($_ids) == count($structures)) {
 
 			// Fine.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.structureAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.structureAdded', TRUE),
@@ -182,7 +182,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 		} else {
 
 			// Something went wrong.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.structureNotAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.structureNotAdded', TRUE),
@@ -213,7 +213,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 			// Check if page is sysfolder.
 			if ($this->pageInfo['doktype'] != 254) {
 
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.wrongPageTypeMsg'),
 					$GLOBALS['LANG']->getLL('flash.wrongPageType', TRUE),
@@ -258,7 +258,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 			if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
 
 				// Fine.
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.structureOkayMsg'),
 					$GLOBALS['LANG']->getLL('flash.structureOkay', TRUE),
@@ -269,9 +269,9 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 			} else {
 
 				// Configuration missing.
-				$_url = t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'addStructure')));
+				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addStructure')));
 
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					sprintf($GLOBALS['LANG']->getLL('flash.structureNotOkayMsg'), $_url),
 					$GLOBALS['LANG']->getLL('flash.structureNotOkay', TRUE),
@@ -293,7 +293,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 			if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
 
 				// Fine.
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.metadataOkayMsg'),
 					$GLOBALS['LANG']->getLL('flash.metadataOkay', TRUE),
@@ -304,9 +304,9 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 			} else {
 
 				// Configuration missing.
-				$_url = t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'addMetadata')));
+				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addMetadata')));
 
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					sprintf($GLOBALS['LANG']->getLL('flash.metadataNotOkayMsg'), $_url),
 					$GLOBALS['LANG']->getLL('flash.metadataNotOkay', TRUE),
@@ -337,7 +337,7 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgview
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/modules/setup/index.php']);
 }
 
-$SOBE = t3lib_div::makeInstance('tx_dfgviewer_modSetup');
+$SOBE = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dfgviewer_modSetup');
 
 $SOBE->main();
 

--- a/dfgviewer/modules/setup/index.php
+++ b/dfgviewer/modules/setup/index.php
@@ -116,10 +116,10 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Fine.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				't3lib_FlashMessage',
+				'\TYPO3\CMS\Core\Messaging\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.metadataAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.metadataAdded', TRUE),
-				t3lib_FlashMessage::OK,
+				\TYPO3\CMS\Core\Messaging\FlashMessage::OK,
 				FALSE
 			);
 
@@ -127,16 +127,16 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Something went wrong.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				't3lib_FlashMessage',
+				'\TYPO3\CMS\Core\Messaging\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.metadataNotAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.metadataNotAdded', TRUE),
-				t3lib_FlashMessage::ERROR,
+				\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
 				FALSE
 			);
 
 		}
 
-		t3lib_FlashMessageQueue::addMessage($_message);
+		tx_dlf_helper::addMessage($_message);
 
 	}
 
@@ -172,10 +172,10 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Fine.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				't3lib_FlashMessage',
+				'\TYPO3\CMS\Core\Messaging\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.structureAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.structureAdded', TRUE),
-				t3lib_FlashMessage::OK,
+				\TYPO3\CMS\Core\Messaging\FlashMessage::OK,
 				FALSE
 			);
 
@@ -183,16 +183,16 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Something went wrong.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				't3lib_FlashMessage',
+				'\TYPO3\CMS\Core\Messaging\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.structureNotAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.structureNotAdded', TRUE),
-				t3lib_FlashMessage::ERROR,
+				\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
 				FALSE
 			);
 
 		}
 
-		t3lib_FlashMessageQueue::addMessage($_message);
+		tx_dlf_helper::addMessage($_message);
 
 	}
 
@@ -214,16 +214,16 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 			if ($this->pageInfo['doktype'] != 254) {
 
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					't3lib_FlashMessage',
+					'\TYPO3\CMS\Core\Messaging\FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.wrongPageTypeMsg'),
 					$GLOBALS['LANG']->getLL('flash.wrongPageType', TRUE),
-					t3lib_FlashMessage::ERROR,
+					\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
 					FALSE
 				);
 
-				t3lib_FlashMessageQueue::addMessage($_message);
+				tx_dlf_helper::addMessage($_message);
 
-				$this->markerArray['CONTENT'] .= t3lib_FlashMessageQueue::renderFlashMessages();
+				$this->markerArray['CONTENT'] .= tx_dlf_helper::renderFlashMessages();
 
 				$this->printContent();
 
@@ -259,10 +259,10 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 				// Fine.
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					't3lib_FlashMessage',
+					'\TYPO3\CMS\Core\Messaging\FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.structureOkayMsg'),
 					$GLOBALS['LANG']->getLL('flash.structureOkay', TRUE),
-					t3lib_FlashMessage::OK,
+					\TYPO3\CMS\Core\Messaging\FlashMessage::OK,
 					FALSE
 				);
 
@@ -272,16 +272,16 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addStructure')));
 
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					't3lib_FlashMessage',
+					'\TYPO3\CMS\Core\Messaging\FlashMessage',
 					sprintf($GLOBALS['LANG']->getLL('flash.structureNotOkayMsg'), $_url),
 					$GLOBALS['LANG']->getLL('flash.structureNotOkay', TRUE),
-					t3lib_FlashMessage::ERROR,
+					\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
 					FALSE
 				);
 
 			}
 
-			t3lib_FlashMessageQueue::addMessage($_message);
+			tx_dlf_helper::addMessage($_message);
 
 			// Check for existing metadata configuration.
 			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
@@ -294,10 +294,10 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 				// Fine.
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					't3lib_FlashMessage',
+					'\TYPO3\CMS\Core\Messaging\FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.metadataOkayMsg'),
 					$GLOBALS['LANG']->getLL('flash.metadataOkay', TRUE),
-					t3lib_FlashMessage::OK,
+					\TYPO3\CMS\Core\Messaging\FlashMessage::OK,
 					FALSE
 				);
 
@@ -307,18 +307,18 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addMetadata')));
 
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					't3lib_FlashMessage',
+					'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 					sprintf($GLOBALS['LANG']->getLL('flash.metadataNotOkayMsg'), $_url),
 					$GLOBALS['LANG']->getLL('flash.metadataNotOkay', TRUE),
-					t3lib_FlashMessage::ERROR,
+					\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
 					FALSE
 				);
 
 			}
 
-			t3lib_FlashMessageQueue::addMessage($_message);
+			tx_dlf_helper::addMessage($_message);
 
-			$this->markerArray['CONTENT'] .= t3lib_FlashMessageQueue::renderFlashMessages();
+			$this->markerArray['CONTENT'] .= tx_dlf_helper::renderFlashMessages();
 
 		} else {
 

--- a/dfgviewer/modules/setup/index.php
+++ b/dfgviewer/modules/setup/index.php
@@ -63,7 +63,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 	protected function cmdAddMetadata() {
 
 		// Include metadata definition file.
-		include_once(t3lib_extMgm::extPath($this->extKey).'modules/'.$this->modPath.'metadata.inc.php');
+		include_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($this->extKey).'modules/'.$this->modPath.'metadata.inc.php');
 
 		// Load table configuration array to get default field values.
 		\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tx_dlf_metadata');
@@ -150,7 +150,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 	protected function cmdAddStructure() {
 
 		// Include structure definition file.
-		include_once(t3lib_extMgm::extPath($this->extKey).'modules/'.$this->modPath.'structures.inc.php');
+		include_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($this->extKey).'modules/'.$this->modPath.'structures.inc.php');
 
 		// Build data array.
 		foreach ($structures as $index_name => $values) {

--- a/dfgviewer/modules/setup/index.php
+++ b/dfgviewer/modules/setup/index.php
@@ -116,7 +116,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Fine.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				'\TYPO3\CMS\Core\Messaging\FlashMessage',
+				'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.metadataAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.metadataAdded', TRUE),
 				\TYPO3\CMS\Core\Messaging\FlashMessage::OK,
@@ -127,7 +127,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Something went wrong.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				'\TYPO3\CMS\Core\Messaging\FlashMessage',
+				'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.metadataNotAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.metadataNotAdded', TRUE),
 				\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
@@ -172,7 +172,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Fine.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				'\TYPO3\CMS\Core\Messaging\FlashMessage',
+				'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.structureAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.structureAdded', TRUE),
 				\TYPO3\CMS\Core\Messaging\FlashMessage::OK,
@@ -183,7 +183,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 			// Something went wrong.
 			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-				'\TYPO3\CMS\Core\Messaging\FlashMessage',
+				'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 				$GLOBALS['LANG']->getLL('flash.structureNotAddedMsg'),
 				$GLOBALS['LANG']->getLL('flash.structureNotAdded', TRUE),
 				\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
@@ -214,7 +214,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 			if ($this->pageInfo['doktype'] != 254) {
 
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					'\TYPO3\CMS\Core\Messaging\FlashMessage',
+					'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.wrongPageTypeMsg'),
 					$GLOBALS['LANG']->getLL('flash.wrongPageType', TRUE),
 					\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
@@ -259,7 +259,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 				// Fine.
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					'\TYPO3\CMS\Core\Messaging\FlashMessage',
+					'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.structureOkayMsg'),
 					$GLOBALS['LANG']->getLL('flash.structureOkay', TRUE),
 					\TYPO3\CMS\Core\Messaging\FlashMessage::OK,
@@ -272,7 +272,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addStructure')));
 
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					'\TYPO3\CMS\Core\Messaging\FlashMessage',
+					'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 					sprintf($GLOBALS['LANG']->getLL('flash.structureNotOkayMsg'), $_url),
 					$GLOBALS['LANG']->getLL('flash.structureNotOkay', TRUE),
 					\TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
@@ -294,7 +294,7 @@ class tx_dfgviewer_modSetup extends tx_dlf_module {
 
 				// Fine.
 				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-					'\TYPO3\CMS\Core\Messaging\FlashMessage',
+					'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 					$GLOBALS['LANG']->getLL('flash.metadataOkayMsg'),
 					$GLOBALS['LANG']->getLL('flash.metadataOkay', TRUE),
 					\TYPO3\CMS\Core\Messaging\FlashMessage::OK,

--- a/dfgviewer/modules/setup/index.php
+++ b/dfgviewer/modules/setup/index.php
@@ -340,5 +340,3 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgview
 $SOBE = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dfgviewer_modSetup');
 
 $SOBE->main();
-
-?>

--- a/dfgviewer/modules/setup/metadata.inc.php
+++ b/dfgviewer/modules/setup/metadata.inc.php
@@ -284,5 +284,3 @@ $metadata = array (
 		'is_listed' => 1,
 	)
 );
-
-?>

--- a/dfgviewer/modules/setup/structures.inc.php
+++ b/dfgviewer/modules/setup/structures.inc.php
@@ -290,5 +290,3 @@ $structures = array (
 		'oai_name' => ''
 	)
 );
-
-?>

--- a/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php
+++ b/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php
@@ -240,7 +240,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 
 			$markerArray['###SPONSORSITEURL###'] = $this->pi_getLL('dfgLink', '', TRUE);
 
-			$markerArray['###SPONSORLOGO###'] = t3lib_extMgm::siteRelPath($this->extKey).'res/images/dfglogo.png';
+			$markerArray['###SPONSORLOGO###'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/images/dfglogo.png';
 
 		}
 

--- a/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php
+++ b/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php
@@ -253,5 +253,3 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php'])	{
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php']);
 }
-
-?>

--- a/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php
+++ b/dfgviewer/plugins/amd/class.tx_dfgviewer_amd.php
@@ -104,7 +104,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 				$markerArray['###OWNER###'] = htmlspecialchars(trim((string) $rights->owner));
 
 				// Get owner's site URL.
-				if (t3lib_div::isValidUrl(trim((string) $rights->ownerSiteURL))
+				if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl(trim((string) $rights->ownerSiteURL))
 					// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 					// the function to validate URLs containing whitespaces and invalidate URLs containing
 					// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -115,7 +115,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 				}
 
 				// Get owner's logo.
-				if (t3lib_div::isValidUrl(trim((string) $rights->ownerLogo))
+				if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl(trim((string) $rights->ownerLogo))
 					// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 					// the function to validate URLs containing whitespaces and invalidate URLs containing
 					// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -126,7 +126,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 				}
 
 				// Get owner's contact information.
-				if (t3lib_div::isValidUrl(trim((string) $rights->ownerContact))
+				if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl(trim((string) $rights->ownerContact))
 					// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 					// the function to validate URLs containing whitespaces and invalidate URLs containing
 					// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -134,7 +134,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 
 					$markerArray['###OWNERCONTACT###'] = htmlspecialchars(trim((string) $rights->ownerContact));
 
-				} elseif (t3lib_div::isValidUrl('mailto:'.trim((string) $rights->ownerContact))
+				} elseif (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl('mailto:'.trim((string) $rights->ownerContact))
 					// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 					// the function to validate URLs containing whitespaces and invalidate URLs containing
 					// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -148,7 +148,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 				$markerArray['###SPONSOR###'] = htmlspecialchars(trim((string) $rights->sponsor));
 
 				// Get sponsor's site URL.
-				if (t3lib_div::isValidUrl(trim((string) $rights->sponsorSiteURL))
+				if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl(trim((string) $rights->sponsorSiteURL))
 					// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 					// the function to validate URLs containing whitespaces and invalidate URLs containing
 					// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -159,7 +159,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 				}
 
 				// Get sponsor's logo.
-				if (t3lib_div::isValidUrl(trim((string) $rights->sponsorLogo))
+				if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl(trim((string) $rights->sponsorLogo))
 					// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 					// the function to validate URLs containing whitespaces and invalidate URLs containing
 					// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -188,7 +188,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 
 				foreach ($links->reference as $reference) {
 
-					if (t3lib_div::isValidUrl(trim((string) $reference))
+					if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl(trim((string) $reference))
 						// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 						// the function to validate URLs containing whitespaces and invalidate URLs containing
 						// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -219,7 +219,7 @@ class tx_dfgviewer_amd extends tx_dlf_plugin {
 				// Get local view.
 				$markerArray['###LOCALVIEW###'] = $this->pi_getLL('localview', '', TRUE);
 
-				if (t3lib_div::isValidUrl(trim((string) $links->presentation))
+				if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl(trim((string) $links->presentation))
 					// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 					// the function to validate URLs containing whitespaces and invalidate URLs containing
 					// hyphens. (see https://bugs.php.net/bug.php?id=51192)

--- a/dfgviewer/plugins/gridpager/class.tx_dfgviewer_gridpager.php
+++ b/dfgviewer/plugins/gridpager/class.tx_dfgviewer_gridpager.php
@@ -71,7 +71,7 @@ class tx_dfgviewer_gridpager extends tx_dlf_plugin {
 			// Set some variable defaults.
 			if (!empty($this->piVars['page'])) {
 
-				$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+				$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
 
 				$this->piVars['pointer'] = intval(floor($this->piVars['page'] / $this->conf['limit']));
 
@@ -79,7 +79,7 @@ class tx_dfgviewer_gridpager extends tx_dlf_plugin {
 
 			if (!empty($this->piVars['pointer'])) {
 
-				$this->piVars['pointer'] = tx_dlf_helper::intInRange($this->piVars['pointer'], 0, $maxPointer, 0);
+				$this->piVars['pointer'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['pointer'], 0, $maxPointer, 0);
 
 			} else {
 

--- a/dfgviewer/plugins/gridpager/class.tx_dfgviewer_gridpager.php
+++ b/dfgviewer/plugins/gridpager/class.tx_dfgviewer_gridpager.php
@@ -181,5 +181,3 @@ class tx_dfgviewer_gridpager extends tx_dlf_plugin {
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/gridpager/class.tx_dfgviewer_gridpager.php'])	{
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/gridpager/class.tx_dfgviewer_gridpager.php']);
 }
-
-?>

--- a/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
+++ b/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
@@ -149,6 +149,8 @@ class tx_dfgviewer_newspapercalendar extends tx_dlf_plugin {
 
 						$currentMonth = date('n', $currentDayTime);
 
+						if ($toc[0]['children'][0]['children'][$month[$currentMonth]]['children']) {
+
 							foreach($toc[0]['children'][0]['children'][$month[$currentMonth]]['children'] as $id => $day) {
 
 								// prefer oderlabel over label
@@ -189,6 +191,7 @@ class tx_dfgviewer_newspapercalendar extends tx_dlf_plugin {
 							}
 
 							$dayLinkDiv = '<div class="tooltip issues" title="'.htmlspecialchars($dayLinksList).'">' . strftime('%d', $currentDayTime) . '</div>';
+						}
 
 						switch (strftime('%u', strtotime('+ '.$k.' Day', $firstDayOfWeek))) {
 							case '1': $weekArray['###DAYMON###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);

--- a/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
+++ b/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
@@ -125,8 +125,6 @@ class tx_dfgviewer_newspapercalendar extends tx_dlf_plugin {
 			// max 6 calendar weeks in a month
 			for ($j = 0; $j <= 5; $j++) {
 
-				$weekArray = array();
-
 				$firstDayOfWeek = strtotime('+ ' . $j . ' Week', $firstOfMonthStart);
 
 				$weekArray = array(

--- a/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
+++ b/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
@@ -68,7 +68,6 @@ class tx_dfgviewer_newspapercalendar extends tx_dlf_plugin {
 		}
 
 		$toc = $this->doc->tableOfContents;
-//~ t3lib_utility_Debug::debug($toc, 'tx_dfgviewer_newspaperyear: conf... ');
 
 		foreach($toc[0]['children'][0]['children'] as $id => $mo) {
 

--- a/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
+++ b/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
@@ -63,7 +63,7 @@ class tx_dfgviewer_newspapercalendar extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+			$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
 
 		}
 

--- a/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
+++ b/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php
@@ -293,5 +293,3 @@ class tx_dfgviewer_newspapercalendar extends tx_dlf_plugin {
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php'])	{
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/newspaper-calendar/class.tx_dfgviewer_newspaper-calendar.php']);
 }
-
-?>

--- a/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php
+++ b/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php
@@ -68,7 +68,6 @@ class tx_dfgviewer_newspaperyears extends tx_dlf_plugin {
 		}
 
 		$toc = $this->doc->tableOfContents;
-//~ t3lib_utility_Debug::debug($toc, 'tx_dfgviewer_newspaperyear: conf... ');
 
 		// Load template file.
 		if (!empty($this->conf['templateFile'])) {
@@ -87,7 +86,6 @@ class tx_dfgviewer_newspaperyears extends tx_dlf_plugin {
 
 		$years = $toc[0]['children'];
 
-		$subPartContent = '';
 		$subYearPartContent = '';
 
 		foreach($years as $id => $year) {

--- a/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php
+++ b/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php
@@ -132,5 +132,3 @@ class tx_dfgviewer_newspaperyears extends tx_dlf_plugin {
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php'])	{
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php']);
 }
-
-?>

--- a/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php
+++ b/dfgviewer/plugins/newspaper-years/class.tx_dfgviewer_newspaper-years.php
@@ -63,7 +63,7 @@ class tx_dfgviewer_newspaperyears extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+			$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
 
 		}
 

--- a/dfgviewer/plugins/sru/class.tx_dfgviewer_sru.php
+++ b/dfgviewer/plugins/sru/class.tx_dfgviewer_sru.php
@@ -246,5 +246,3 @@ class tx_dfgviewer_sru extends tx_dlf_plugin {
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/sru/class.tx_dfgviewer_sru.php'])	{
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/sru/class.tx_dfgviewer_sru.php']);
 }
-
-?>

--- a/dfgviewer/plugins/sru/class.tx_dfgviewer_sru.php
+++ b/dfgviewer/plugins/sru/class.tx_dfgviewer_sru.php
@@ -172,7 +172,7 @@ class tx_dfgviewer_sru extends tx_dlf_plugin {
 		// Add javascript to page header.
 		if (tx_dlf_helper::loadJQuery()) {
 
-			$GLOBALS['TSFE']->additionalHeaderData[$this->prefixId.'_sru'] = '<script type="text/javascript" src="'.t3lib_extMgm::siteRelPath($this->extKey).'plugins/sru/tx_dfgviewer_sru.js"></script>';
+			$GLOBALS['TSFE']->additionalHeaderData[$this->prefixId.'_sru'] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/sru/tx_dfgviewer_sru.js"></script>';
 
 		}
 

--- a/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
+++ b/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
@@ -207,5 +207,3 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgview
 $cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dfgviewer_sru_eid');
 
 $cObj->main();
-
-?>

--- a/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
+++ b/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
@@ -52,17 +52,17 @@ class tx_dfgviewer_sru_eid extends tslib_pibase {
 	 */
 	public function main($content = '', $conf = array ()) {
 
-		$this->cObj = t3lib_div::makeInstance('tslib_cObj');
+		$this->cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tslib_cObj');
 
 		$this->extKey = 'dfgviewer';
 
 		$this->scriptRelPath = 'plugins/sru/class.tx_dfgviewer_sru_eid.php';
 
-		$this->LLkey = t3lib_div::_GP('L') ? t3lib_div::_GP('L') : 'default';
+		$this->LLkey = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('L') ? \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('L') : 'default';
 
 		$this->pi_loadLL();
 
-		$url = t3lib_div::_GP('sru') . '?operation=searchRetrieve&version=1.2&startRecord=1&maximumRecords=10&amp;recordSchema=dfg-viewer/page&amp;query=' . urlencode(t3lib_div::_GP('q'));
+		$url = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('sru') . '?operation=searchRetrieve&version=1.2&startRecord=1&maximumRecords=10&amp;recordSchema=dfg-viewer/page&amp;query=' . urlencode(\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('q'));
 
 		// make request to SRU service
 		$sruXML = simplexml_load_file($url);
@@ -75,7 +75,7 @@ class tx_dfgviewer_sru_eid extends tslib_pibase {
 
 			if ($sruResponse === FALSE) {
 
-				$results['error'] =  $this->pi_getLL('label.noresults') . ' ' . t3lib_div::_GP('q') ;
+				$results['error'] =  $this->pi_getLL('label.noresults') . ' ' . \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('q') ;
 
 			} else {
 
@@ -83,7 +83,7 @@ class tx_dfgviewer_sru_eid extends tslib_pibase {
 
 				if ($sruRecords === FALSE || empty($sruRecords) ) {
 
-					$results['error'] =  $this->pi_getLL('label.noresults') . ' ' . t3lib_div::_GP('q') ;
+					$results['error'] =  $this->pi_getLL('label.noresults') . ' ' . \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('q') ;
 
 				}
 
@@ -190,7 +190,7 @@ class tx_dfgviewer_sru_eid extends tslib_pibase {
 
 		} else {
 
-			$results['error'] =  $this->pi_getLL('label.noresults') . ' ' . t3lib_div::_GP('q') ;
+			$results['error'] =  $this->pi_getLL('label.noresults') . ' ' . \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('q') ;
 
 		}
 
@@ -204,7 +204,7 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgview
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/search/class.tx_dfgviewer_sru_eid.php']);
 }
 
-$cObj = t3lib_div::makeInstance('tx_dfgviewer_sru_eid');
+$cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dfgviewer_sru_eid');
 
 $cObj->main();
 

--- a/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
+++ b/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
@@ -45,12 +45,9 @@ class tx_dfgviewer_sru_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 	 *
 	 * @access	public
 	 *
-	 * @param	string		$content: The PlugIn content
-	 * @param	array		$conf: The PlugIn configuration
-	 *
-	 * @return	void
+	 * @return string JSON encoded return value
 	 */
-	public function main($content = '', $conf = array ()) {
+	public function main() {
 
 		$this->cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
 

--- a/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
+++ b/dfgviewer/plugins/sru/class.tx_dfgviewer_sru_eid.php
@@ -32,7 +32,7 @@
  * @subpackage	tx_dfgviewer
  * @access	public
  */
-class tx_dfgviewer_sru_eid extends tslib_pibase {
+class tx_dfgviewer_sru_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 	/**
 	 *
@@ -52,7 +52,7 @@ class tx_dfgviewer_sru_eid extends tslib_pibase {
 	 */
 	public function main($content = '', $conf = array ()) {
 
-		$this->cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tslib_cObj');
+		$this->cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
 
 		$this->extKey = 'dfgviewer';
 

--- a/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
+++ b/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
@@ -96,13 +96,13 @@ class tx_dfgviewer_uri extends tx_dlf_plugin {
 		);
 
 		// Get persistent identifier of book.
-		$uriBook = t3lib_div::trimExplode(' ', $this->doc->physicalPagesInfo[$this->doc->physicalPages[0]]['contentIds'], TRUE);
+		$uriBook = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(' ', $this->doc->physicalPagesInfo[$this->doc->physicalPages[0]]['contentIds'], TRUE);
 
 		if (empty($uriBook)) {
 
 			$uriBook = $this->doc->getLogicalStructure($this->doc->toplevelId);
 
-			$uriBook = t3lib_div::trimExplode(' ', $uriBook['contentIds'], TRUE);
+			$uriBook = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(' ', $uriBook['contentIds'], TRUE);
 
 		}
 
@@ -141,7 +141,7 @@ class tx_dfgviewer_uri extends tx_dlf_plugin {
 		}
 
 		// Get persistent identifier of page.
-		$uriPage = t3lib_div::trimExplode(' ', $this->doc->physicalPagesInfo[$this->doc->physicalPages[$this->piVars['page']]]['contentIds'], TRUE);
+		$uriPage = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(' ', $this->doc->physicalPagesInfo[$this->doc->physicalPages[$this->piVars['page']]]['contentIds'], TRUE);
 
 		if (!empty($uriPage)) {
 

--- a/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
+++ b/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
@@ -69,7 +69,7 @@ class tx_dfgviewer_uri extends tx_dlf_plugin {
 			// page may be integer or string (pyhsical page attribute)
 			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
 
-				$this->piVars['page'] = tx_dlf_helper::intInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
+				$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
 
 			} else {
 

--- a/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
+++ b/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php
@@ -186,5 +186,3 @@ class tx_dfgviewer_uri extends tx_dlf_plugin {
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php'])	{
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dfgviewer/plugins/uri/class.tx_dfgviewer_uri.php']);
 }
-
-?>

--- a/dfgviewer/typoscript/setup.txt
+++ b/dfgviewer/typoscript/setup.txt
@@ -259,7 +259,7 @@ plugin.tx_dfgviewer_newspaperyears {
 	templateFile = {$plugin.tx_dfgviewer.templateFileNewspaperYears}
 }
 
-[userFunc = user_dlf_docTypeCheck({$plugin.tx_dfgviewer.storagePid}:newspaper_global_anchor)]
+[userFunc = user_dlf_docTypeCheck({$plugin.tx_dfgviewer.storagePid}, newspaper_global_anchor)]
 page.2.template.file = {$plugin.tx_dfgviewer.templateFileNewspaper}
 page.2.marks.IMAGE < plugin.tx_dfgviewer_newspaperyears
 page.2.marks.GRIDSWITCHER >
@@ -268,7 +268,7 @@ page.2.marks.SRU < plugin.tx_dfgviewer_sru
 page.2.marks.GUI = TEXT
 [global]
 
-[userFunc = user_dlf_docTypeCheck({$plugin.tx_dfgviewer.storagePid}:newspaper_year_anchor)]
+[userFunc = user_dlf_docTypeCheck({$plugin.tx_dfgviewer.storagePid}, newspaper_year_anchor)]
 page.2.template.file = {$plugin.tx_dfgviewer.templateFileNewspaper}
 page.2.marks.IMAGE < plugin.tx_dfgviewer_newspapercalendar
 page.2.marks.GRIDSWITCHER >
@@ -277,14 +277,11 @@ page.2.marks.SRU < plugin.tx_dfgviewer_sru
 page.2.marks.GUI = TEXT
 [global]
 
-[userFunc = user_dlf_docTypeCheck({$plugin.tx_dfgviewer.storagePid}:newspaper_issue)]
+[userFunc = user_dlf_docTypeCheck({$plugin.tx_dfgviewer.storagePid}, newspaper_issue)]
 page.2.marks.GUI < plugin.tx_dlf_navigation
 page.2.marks.IMAGE < plugin.tx_dlf_pageview
 page.2.marks.NAVIGATION < plugin.tx_dlf_toc
 page.2.marks.SRU < plugin.tx_dfgviewer_sru
-
-#page.2.marks.GUI = TEXT
-#page.2.marks.GUI.value = Hallo Welt! newspaper_issue
 [global]
 
 

--- a/dfgviewer/typoscript/setup.txt
+++ b/dfgviewer/typoscript/setup.txt
@@ -10,7 +10,7 @@ config {
 	xhtml_cleaning = all
 	doctype = xhtml_strict
 	removeDefaultJS = 1
-	baseURL = {$plugin.tx_dfgviewer.baseURL}
+	absRefPrefix = /
 	linkVars = L
 	uniqueLinkVars = 1
 	cache_period = 86400


### PR DESCRIPTION
In goobi/goobi-presentation code changes have been done to replace deprecated classes. The support for TYPO3 4.x has been dropped. The aim is to support TYPO3 from 6.2 up to 7.6.

As the dfgviewer extension relies on Goobi.Presentation, this work had to be done here too.