### PR TITLE
Fix strange case sensitivity issue

### DIFF
--- a/dfgviewer/Classes/ViewHelpers/DownloadLinksViewHelper.php
+++ b/dfgviewer/Classes/ViewHelpers/DownloadLinksViewHelper.php
@@ -51,7 +51,7 @@ class DownloadLinksViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractV
      */
     public function render($type = 'page-left', $pagenumber = 1)
     {
-        $doc = GeneralUtility::makeInstance(\SLUB\Dfgviewer\Helpers\GetDoc::class);
+        $doc = GeneralUtility::makeInstance(\Slub\Dfgviewer\Helpers\GetDoc::class);
 
         switch ($type) {
           case 'page-right':

--- a/dfgviewer/Classes/ViewHelpers/XpathViewHelper.php
+++ b/dfgviewer/Classes/ViewHelpers/XpathViewHelper.php
@@ -51,7 +51,7 @@ class XpathViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelpe
      */
     public function render($xpath, $field = '')
     {
-        $doc = GeneralUtility::makeInstance(\SLUB\Dfgviewer\Helpers\GetDoc::class);
+        $doc = GeneralUtility::makeInstance(\Slub\Dfgviewer\Helpers\GetDoc::class);
 
         $result = $doc->getXpath($xpath);
 


### PR DESCRIPTION
The test request described in dfgviewer/Documentation/Index.rst resulted
in an error on my system (Ubuntu 17.10, PHP 7.1.11, TYPO3 7.6.23):
"Core: Exception handler (WEB): Uncaught TYPO3 Exception: Class
'SLUB\Dfgviewer\Helpers\GetDoc' not found"

Replacing 'SLUB' with 'Slub' in the GeneralUtility::makeInstance() call
in XPathViewHelper to exactly match the namespace solves the problem and
should not result in any problems on other systems.

Same change is applied to DownloadLinksViewHelper.