### PR TITLE
Avoid double htmlspecialchars() in link ViewHelper

### DIFF
--- a/dfgviewer/Classes/ViewHelpers/XpathViewHelper.php
+++ b/dfgviewer/Classes/ViewHelpers/XpathViewHelper.php
@@ -47,9 +47,10 @@ class XpathViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelpe
      *
      * @param string $xpath xpath of elements
      * @param string $type type of field requested
+     * @param boolean $htmlspecialchars use htmlspecialchars() on the found result
      * @return string
      */
-    public function render($xpath, $field = '')
+    public function render($xpath, $field = '', $htmlspecialchars = TRUE)
     {
         $doc = GeneralUtility::makeInstance(\Slub\Dfgviewer\Helpers\GetDoc::class);
 
@@ -63,6 +64,10 @@ class XpathViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelpe
           $output = trim($result);
         }
 
-        return htmlspecialchars(trim($output));
+        if ($htmlspecialchars) {
+          return htmlspecialchars(trim($output));
+        } else {
+          return trim($output);
+        }
     }
 }

--- a/dfgviewer/Resources/Private/Partials/PageView.html
+++ b/dfgviewer/Resources/Private/Partials/PageView.html
@@ -32,7 +32,7 @@
     </f:if>
     <div class="document-functions">
         <div class="provider">
-          <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]' />" title="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]' />">
+          <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]' htmlspecialchars='FALSE' />" title="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]' />">
           <img src="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:ownerLogo)[1]' />"
             title="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:owner)[1]' />"
             alt="Abbildung eines Logo"
@@ -59,7 +59,7 @@
               <li>
                 <f:if condition="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:presentation)[1]' />">
                   <f:then>
-                    <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:presentation)[1]' />" class="local-presentation" title="<f:translate key='provider.local_presentation' extensionName='dfgviewer' />"><f:translate key='provider.local_presentation' extensionName='dfgviewer' /></f:link.external>
+                    <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:presentation)[1]' htmlspecialchars='FALSE' />" class="local-presentation" title="<f:translate key='provider.local_presentation' extensionName='dfgviewer' />"><f:translate key='provider.local_presentation' extensionName='dfgviewer' /></f:link.external>
                   </f:then>
                   <f:else>
                     <span class="local-presentation" title="<f:translate key='provider.no_local_presentation' extensionName='dfgviewer' />"><f:translate key='provider.no_local_presentation' extensionName='dfgviewer' /></span>
@@ -71,17 +71,17 @@
                   <li>
                     <f:if condition="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:reference/@linktext)[{index}]' />">
                       <f:then>
-                        <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:reference)[{index}]' />" class="local-catalog" title="<f:translate key='provider.local_catalogue' extensionName='dfgviewer' />"><dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE="DVLINKS"]/mets:xmlData/dv:links/dv:reference/@linktext)[{index}]' /></f:link.external>
+                        <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:reference)[{index}]' htmlspecialchars='FALSE' />" class="local-catalog" title="<f:translate key='provider.local_catalogue' extensionName='dfgviewer' />"><dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE="DVLINKS"]/mets:xmlData/dv:links/dv:reference/@linktext)[{index}]' /></f:link.external>
                       </f:then>
                       <f:else>
-                        <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:reference)[{index}]' />" class="local-catalog" title="<f:translate key='provider.local_catalogue' extensionName='dfgviewer' />"><f:translate key='provider.local_catalogue' extensionName='dfgviewer' /></f:link.external>
+                        <f:link.external uri="<dv:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\"DVLINKS\"]/mets:xmlData/dv:links/dv:reference)[{index}]' htmlspecialchars='FALSE' />" class="local-catalog" title="<f:translate key='provider.local_catalogue' extensionName='dfgviewer' />"><f:translate key='provider.local_catalogue' extensionName='dfgviewer' /></f:link.external>
                       </f:else>
                     </f:if>
                   </li>
                 </f:if>
               </f:for>
               <li>
-                  <f:link.email email="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerContact)[1]' />" class="local-contact" title="<f:translate key='provider.email_provider' extensionName='dfgviewer' /> (<dv:xpath xpath='//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:owner' />)"><f:translate key='provider.email_provider' extensionName='dfgviewer' /></f:link.email>
+                  <f:link.email email="<dv:xpath xpath='(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerContact)[1]' htmlspecialchars='FALSE' />" class="local-contact" title="<f:translate key='provider.email_provider' extensionName='dfgviewer' /> (<dv:xpath xpath='//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:owner' />)"><f:translate key='provider.email_provider' extensionName='dfgviewer' /></f:link.email>
               </li>
                 <f:cObject typoscriptObjectPath="plugin.tx_dfgviewer_uri" />
             </ul>
@@ -122,7 +122,7 @@
               <f:if condition="<dv:xpath xpath='(//mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:extension/slub:slub/slub:id[@type=\'digital\'])[1]' />">
                 <li>
                   <f:link.external
-                    uri="http://digital.slub-dresden.de/fileadmin/data/<dv:xpath xpath='(//mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:extension/slub:slub/slub:id[@type=\'digital\'])[1]' />/<dv:xpath xpath='(//mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:extension/slub:slub/slub:id[@type=\'digital\'])[1]' />_tif/jpegs/<dv:xpath xpath='(//mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:extension/slub:slub/slub:id[@type=\'digital\'])[1]' />.pdf"
+                    uri="http://digital.slub-dresden.de/fileadmin/data/<dv:xpath xpath='(//mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:extension/slub:slub/slub:id[@type=\'digital\'])[1]' htmlspecialchars='FALSE' />/<dv:xpath xpath='(//mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:extension/slub:slub/slub:id[@type=\'digital\'])[1]' htmlspecialchars='FALSE' />_tif/jpegs/<dv:xpath xpath='(//mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:extension/slub:slub/slub:id[@type=\'digital\'])[1]' />.pdf"
                     class="download-document"
                     target="_blank"
                     title="<f:translate key='download.work' extensionName='dfgviewer' />"><f:translate key="download.work"  extensionName="dfgviewer" />


### PR DESCRIPTION
The fluid tag based viewhelper use already the htmlspecialchars()
function to escape special characters. Doing this in the dfgviewer xpath
viewhelper another time will result in rare cases in broken links.

e.g. &amp; is getting &amp;amp;

This patch adds an attribute "htmlspecialchars" which is TRUE by
default. Only in case of the link viewhelper, we set it to FALSE.