### PR TITLE
Fix double escaping of catalogue links

### DIFF
--- a/Resources/Private/Partials/PageView.html
+++ b/Resources/Private/Partials/PageView.html
@@ -77,7 +77,7 @@
                         <f:link.external uri="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]', htmlspecialchars:'FALSE')}" class="local-catalog" title="{f:translate(key:'provider.local_catalogue', extensionName:'dfgviewer')}"><dc:xpath xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE="DVLINKS"]/mets:xmlData/dv:links/dv:reference/@linktext)[{index}]' /></f:link.external>
                       </f:then>
                       <f:else>
-                        <f:link.external uri="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]')}" class="local-catalog" title="{f:translate(key:'provider.local_catalogue', extensionName:'dfgviewer')}"><f:translate key='provider.local_catalogue' extensionName='dfgviewer' /></f:link.external>
+                        <f:link.external uri="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]', htmlspecialchars:'FALSE')}" class="local-catalog" title="{f:translate(key:'provider.local_catalogue', extensionName:'dfgviewer')}"><f:translate key='provider.local_catalogue' extensionName='dfgviewer' /></f:link.external>
                       </f:else>
                     </f:if>
                   </li>


### PR DESCRIPTION
This has been removed by #152. 
In case of URIs with reserved characters (`&amp;`) the URI will be encoded with htmlspecialchars twice.