### PR TITLE
Add (again) aggregator and sponsor logos if available

### DIFF
--- a/Resources/Private/Partials/PageView.html
+++ b/Resources/Private/Partials/PageView.html
@@ -35,23 +35,61 @@
     </f:if>
     <div class="document-functions">
         <div class="provider">
-            <f:alias map="{providerLogoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerLogo)[1]\')}',
-                providerTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]\')}',
-                providerUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]\', htmlspecialchars:\'FALSE\')}'}">
-                <f:if condition="{settings.showProviderLogo} && {dc:providerLogoCached(logo:'{providerLogoUrl}')}">
-                    <f:if condition="{providerLogoUrl}">
-                    <f:link.external
-                        uri="{providerUri}"
-                        title="{providerTitle}">
-                        <img src="/typo3temp/assets/images/{dc:providerLogoCached(logo:'{providerLogoUrl}')}"
-                            width="108"
-                            title="{providerTitle}"
-                            alt="Logo von {providerTitle}"
-                        />
-                    </f:link.external>
-                    </f:if>
-                </f:if>
-            </f:alias>
+            <f:if condition="{settings.showProviderLogo}">
+                <ul>
+                    <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerLogo)[1]\')}',
+                        logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]\')}',
+                        logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]\', htmlspecialchars:\'FALSE\')}'}">
+                        <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
+                            <li>
+                                <f:link.external
+                                    uri="{logoUri}"
+                                    title="{logoTitle}">
+                                    <img src="/typo3temp/assets/images/{dc:providerLogoCached(logo:'{logoUrl}')}"
+                                        width="108"
+                                        title="{logoTitle}"
+                                        alt="Logo von {logoTitle}"
+                                    />
+                                </f:link.external>
+                            </li>
+                        </f:if>
+                    </f:alias>
+                    <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorLogo)[1]\')}',
+                        logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregator)[1]\')}',
+                        logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorSiteURL)[1]\', htmlspecialchars:\'FALSE\')}'}">
+                        <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
+                            <li>
+                                <f:link.external
+                                    uri="{logoUri}"
+                                    title="{logoTitle}">
+                                    <img src="/typo3temp/assets/images/{dc:providerLogoCached(logo:'{logoUrl}')}"
+                                        width="108"
+                                        title="{logoTitle}"
+                                        alt="Logo von {logoTitle}"
+                                    />
+                                </f:link.external>
+                            </li>
+                        </f:if>
+                    </f:alias>
+                    <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorLogo)[1]\')}',
+                        logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsor)[1]\')}',
+                        logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorSiteURL)[1]\', htmlspecialchars:\'FALSE\')}'}">
+                        <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
+                            <li>
+                                <f:link.external
+                                    uri="{logoUri}"
+                                    title="{logoTitle}">
+                                    <img src="/typo3temp/assets/images/{dc:providerLogoCached(logo:'{logoUrl}')}"
+                                        width="108"
+                                        title="{logoTitle}"
+                                        alt="Logo von {logoTitle}"
+                                    />
+                                </f:link.external>
+                            </li>
+                        </f:if>
+                    </f:alias>
+                </ul>
+            </f:if>
 
             <dl class="mobile-meta">
                 <dt class="tx-dlf-title">Titel</dt>


### PR DESCRIPTION
This adds the two extra logos for aggregators and sponsors if available below the provider logo.

This will fix #178.