### PR TITLE
Remove config.absRefPrefix

### DIFF
--- a/Configuration/TypoScript/Config/config.typoscript
+++ b/Configuration/TypoScript/Config/config.typoscript
@@ -21,7 +21,6 @@ config {
   spamProtectEmailAddresses_atSubst = &#64;
 
   prefixLocalAnchors = all
-  absRefPrefix = /
   simulateStaticDocuments = 0
 
   meaningfulTempFilePrefix = 1


### PR DESCRIPTION
It is not needed, and setting it prevents installation in a subdirectory.

Signed-off-by: Stefan Weil <sw@weilnetz.de>