### PR TITLE
Fix HTML5 warning by removing type attribut from script

### DIFF
--- a/Resources/Private/Partials/Piwik.html
+++ b/Resources/Private/Partials/Piwik.html
@@ -3,7 +3,7 @@
       lang="en">
 
 <f:section name="Piwik">
-<script type="text/javascript">
+<script>
   var _paq = _paq || [];
   _paq.push(["setDomains", ["{piwik_domains}"]]);
   _paq.push(['trackPageView']);


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>