### PR TITLE
Fix dlf path: `Javascript` -> `JavaScript`

### DIFF
--- a/Configuration/TypoScript/Page/header.typoscript
+++ b/Configuration/TypoScript/Page/header.typoscript
@@ -13,7 +13,7 @@ page {
   includeJSFooterlibs {
     jQuery = EXT:dfgviewer/Resources/Public/JavaScript/jQuery/jquery-3.6.0.min.js
     jQuery.forceOnTop = 1
-    jQueryUiMouseSlider = EXT:dlf/Resources/Public/Javascript/jQueryUI/jquery-ui-mouse-slider-resizable-autocomplete.js
+    jQueryUiMouseSlider = EXT:dlf/Resources/Public/JavaScript/jQueryUI/jquery-ui-mouse-slider-resizable-autocomplete.js
     dfgviewer = EXT:dfgviewer/Resources/Public/JavaScript/webScripts.js
   }
 


### PR DESCRIPTION
Corrects an error appearing after fixing following errors in presentation (https://github.com/kitodo/kitodo-presentation/issues/904) which occurred after PR (https://github.com/kitodo/kitodo-presentation/pull/877) which renamed the directories `Javascript` and `Flexforms` to camel-case in accordance with the TYPO3 Coding Guidelines.

In this case the extension tried to reach the path `/var/www/typo3/public/typo3conf/ext/dlf/Resources/Public/Javascript/jQueryUI/jquery-ui-mouse-slider-resizable-autocomplete.js` which had the non camel-case writing.