### PR TITLE
Show provider logo again

### DIFF
--- a/Resources/Private/Partials/PageView.html
+++ b/Resources/Private/Partials/PageView.html
@@ -59,11 +59,9 @@
         <div class="provider">
           <f:if condition="{settings.showProviderLogo}">
             <ul>
-              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"
-                DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerLogo)[1]\')}', logoTitle: '{dc:xpath(xpath:\'
-                (//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]\')}',
-                logoUri: '{dc:xpath(xpath:\'
-                (//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]\',
+              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerLogo)[1]\')}',
+                logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]\')}',
+                logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]\',
                 htmlspecialchars:\'FALSE\')}'}">
                 <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
                   <li>
@@ -74,11 +72,9 @@
                   </li>
                 </f:if>
               </f:alias>
-              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"
-                DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorLogo)[1]\')}', logoTitle: '{dc:xpath(xpath:\'
-                (//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregator)[1]\')}',
-                logoUri: '{dc:xpath(xpath:\'
-                (//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorSiteURL)[1]\',
+              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorLogo)[1]\')}',
+                logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregator)[1]\')}',
+                logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorSiteURL)[1]\',
                 htmlspecialchars:\'FALSE\')}'}">
                 <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
                   <li>
@@ -89,11 +85,9 @@
                   </li>
                 </f:if>
               </f:alias>
-              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"
-                DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorLogo)[1]\')}', logoTitle: '{dc:xpath(xpath:\'
-                (//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsor)[1]\')}',
-                logoUri: '{dc:xpath(xpath:\'
-                (//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorSiteURL)[1]\',
+              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorLogo)[1]\')}',
+                logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsor)[1]\')}',
+                logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorSiteURL)[1]\',
                 htmlspecialchars:\'FALSE\')}'}">
                 <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
                   <li>


### PR DESCRIPTION
Due to line breaks on xpaths in https://github.com/slub/dfg-viewer/blob/master/Resources/Private/Partials/PageView.html#L62 (and ongoing lines) the provider logo was not shown:

Missing: ![grafik](https://user-images.githubusercontent.com/43964592/217305988-41fd3f45-d462-4609-8585-25fc00ddf7f4.png)  -> Not missing: ![grafik](https://user-images.githubusercontent.com/43964592/217306043-0e5489b4-f056-4d58-89bb-f794cd82381f.png)

This PR reverts (only) the line breaks from 17bddfc433f111ef8c41ec2078afdde869e27590 to their previous state. 

Signed-off-by: Christos Sidiropoulos <csidirop@runbox.com>