### PR TITLE
Fix position provider logo in fullscreen

### DIFF
--- a/Resources/Private/Less/structure.less
+++ b/Resources/Private/Less/structure.less
@@ -274,7 +274,7 @@ a {
                 }
             }
             .fullscreen & {
-                .transform(translateY(-100%));
+                .transform(translateY(-10%));
             }
         }
         &.missing-provider-image {


### PR DESCRIPTION
Corrects the position of the provider logo in fullscreen

Before clicking on the fullscreen icon
![image](https://user-images.githubusercontent.com/4037984/224980579-0795fe46-29b5-4087-8f3f-1620095b95a6.png)

After clicking on the fullscreen icon
![image](https://user-images.githubusercontent.com/4037984/224980858-7cd117bf-3a38-4c1e-86a8-6c258592b90a.png)

With the patch
![image](https://user-images.githubusercontent.com/4037984/224981332-fcd758e2-4738-4d00-89cc-56e143286544.png)

To see the logo #221 is necessary