### PR TITLE
Fix typeerror exception which accured after presentations xss vulnerabitlity fix

### DIFF
--- a/Classes/Controller/UriController.php
+++ b/Classes/Controller/UriController.php
@@ -47,7 +47,7 @@ class UriController extends \Kitodo\Dlf\Controller\AbstractController
     public function mainAction()
     {
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument((int) $this->requestData['id']);
 
         if ($this->document === null) {
             return;


### PR DESCRIPTION
A type error occurred (see below) after an xss vulnerability in presentation got fixed (https://github.com/kitodo/kitodo-presentation/commit/cd528de854b01e393e23288553d0c6a4040f907b). 

This commit changes the call to comply with the new parameter requirements (integer instead of typeless -> here an array).

The error message:
`Core: Exception handler (WEB): Uncaught TYPO3 Exception: Argument 1 passed to Kitodo\Dlf\Controller\AbstractController::loadDocument() must be of the type int, array given, called in /var/www/typo3/public/typo3conf/ext/dfgviewer/Classes/Controller/UriController.php on line 50 | TypeError thrown in file /var/www/typo3/public/typo3conf/ext/dlf/Classes/Controller/AbstractController.php in line 133.`