### PR TITLE
Fix license comments in LESS file headers

### DIFF
--- a/Resources/Private/JavaScript/dfgviewerScripts.js
+++ b/Resources/Private/JavaScript/dfgviewerScripts.js
@@ -198,5 +198,3 @@ function hideBrowserAlert(){
     Cookies.set('tx-dlf-pageview-hidebrowseralert', 'true', { sameSite: 'lax' });
 
 }
-
-// EOF

--- a/Resources/Private/JavaScript/websiteScripts.js
+++ b/Resources/Private/JavaScript/websiteScripts.js
@@ -59,5 +59,3 @@ $(document).ready(function() {
     // switch on code highlighting
     hljs.highlightAll();
 });
-
-// EOF

--- a/Resources/Private/Less/all.less
+++ b/Resources/Private/Less/all.less
@@ -5,9 +5,6 @@
  * The complete LESS bindings for the
  * whole new DFG viewer
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 // Helpers & variables
@@ -28,5 +25,3 @@
 @import "modules/fulltext.less";
 @import "modules/gridview.less";
 @import "modules/sidebar.less";
-
-// EOF

--- a/Resources/Private/Less/components/audioplayer.less
+++ b/Resources/Private/Less/components/audioplayer.less
@@ -4,9 +4,6 @@
  * ================================================
  * Styles for the jPlayer in 'Tonträger' section
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 /* ==============[ general settings for jPlayer ]=============================== */
@@ -211,5 +208,3 @@
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/components/controls.less
+++ b/Resources/Private/Less/components/controls.less
@@ -5,9 +5,6 @@
  * Control elements like next and previous buttons,
  * download buttons and so on...
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 /* ==============[ basic settings for document control and view buttons ]================= */

--- a/Resources/Private/Less/components/controls.less
+++ b/Resources/Private/Less/components/controls.less
@@ -940,4 +940,3 @@
         color: black;
     }
 }
-// EOF

--- a/Resources/Private/Less/components/newspapers.less
+++ b/Resources/Private/Less/components/newspapers.less
@@ -5,9 +5,6 @@
  * All styles for newspaper specials like
  * calendar and issue views
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 /* ==============[ general settings for newspaper related things ]======================== */
@@ -117,7 +114,7 @@
                             content: " ";
                             opacity: 0;
                             .transform(translateY(15px));
-                            .transition(); 
+                            .transition();
                         }
                         .no-touchevents & {
                             cursor: pointer;
@@ -311,5 +308,3 @@
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/components/normalize.less
+++ b/Resources/Private/Less/components/normalize.less
@@ -5,9 +5,6 @@
  * Reset some browser based settings to start from
  * a clean white sheet of paper
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, font, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td { background: transparent; border: 0; margin: 0; padding: 0; vertical-align: baseline; }
@@ -19,5 +16,3 @@ blockquote:before, blockquote:after { content: ''; content: none; }
 del { text-decoration: line-through; }
 table { border-collapse: collapse; border-spacing: 0; }
 a img { border: none; }
-
-// EOF

--- a/Resources/Private/Less/components/sru.less
+++ b/Resources/Private/Less/components/sru.less
@@ -2,11 +2,8 @@
  *
  * SRU
  * ================================================
- * Inline search field with results and 
+ * Inline search field with results and
  * additionals (placed in document functions)
- *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
  *
  */
 

--- a/Resources/Private/Less/mixins.less
+++ b/Resources/Private/Less/mixins.less
@@ -5,9 +5,6 @@
  * All the mixins for clearfixes, text removal,
  * gradients and some other minor stuff
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .clearfix() {
@@ -62,5 +59,3 @@
   -ms-transform: @transform;
   transform: @transform;
 }
-
-// EOF

--- a/Resources/Private/Less/modules/fulltext.less
+++ b/Resources/Private/Less/modules/fulltext.less
@@ -4,9 +4,6 @@
  * ================================================
  * Specials for the fulltext view
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .fulltext-container {
@@ -83,5 +80,3 @@
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/modules/gridview.less
+++ b/Resources/Private/Less/modules/gridview.less
@@ -5,9 +5,6 @@
  * All special styles for the gridview which shows
  * multiple pages of one document side by side
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .tx-dlf-pagegrid-list {
@@ -154,5 +151,3 @@
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/modules/home.less
+++ b/Resources/Private/Less/modules/home.less
@@ -4,11 +4,6 @@
  * ================================================
  * Styles for the DFG Viewer homepage
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 
-
-// EOF

--- a/Resources/Private/Less/modules/sidebar.less
+++ b/Resources/Private/Less/modules/sidebar.less
@@ -5,9 +5,6 @@
  * Special styles for the blue sidebar which
  * represents the base control unit in DFG viewer
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .control-bar {
@@ -520,5 +517,3 @@ ul.toc {
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/rte.less
+++ b/Resources/Private/Less/rte.less
@@ -135,6 +135,3 @@ body {
         overflow: hidden;
     }
 }
-
-
-// EOF

--- a/Resources/Private/Less/structure.less
+++ b/Resources/Private/Less/structure.less
@@ -5,9 +5,6 @@
  * Basic definition of body, cotainers and other
  * structural elements
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 /* ==============[ first things first. simple font import. ]=============================== */
@@ -343,5 +340,3 @@ a {
         left: 25%;
     }
 }
-
-// EOF

--- a/Resources/Private/Less/variables.less
+++ b/Resources/Private/Less/variables.less
@@ -5,9 +5,6 @@
  * Value settings for type, breakpoints and
  * base settings for calculations
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 // Base value
@@ -25,5 +22,3 @@
 @okay-green: rgb(0,153,0);
 @warning-red: rgb(182, 23, 23);
 @font-grey: rgb(85,85,85);
-
-// EOF

--- a/Resources/Private/Less/website.less
+++ b/Resources/Private/Less/website.less
@@ -5,9 +5,6 @@
  * Only combines the project basics (variables and
  * mixins) with the website styles
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 // Helpers & variables
@@ -25,5 +22,3 @@
 @import "website/header.less";
 @import "website/content.less";
 @import "website/home.less";
-
-// EOF

--- a/Resources/Private/Less/website/content.less
+++ b/Resources/Private/Less/website/content.less
@@ -5,9 +5,6 @@
  * All styles for the DFG Viewer website which
  * embraces the viewer itself
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .website {
@@ -236,5 +233,3 @@
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/website/header.less
+++ b/Resources/Private/Less/website/header.less
@@ -5,9 +5,6 @@
  * All styles for the DFG Viewer website which
  * embraces the viewer itself
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .website {
@@ -520,5 +517,3 @@
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/website/home.less
+++ b/Resources/Private/Less/website/home.less
@@ -5,9 +5,6 @@
  * All styles for the DFG Viewer website which
  * embraces the viewer itself
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .website.home {
@@ -271,5 +268,3 @@
         }
     }
 }
-
-// EOF

--- a/Resources/Private/Less/website/structure.less
+++ b/Resources/Private/Less/website/structure.less
@@ -5,9 +5,6 @@
  * All styles for the DFG Viewer website which
  * embraces the viewer itself
  *
- * Author: Thomas Jung <thomas@tjwd.de>
- * License: All rights reserved
- *
  */
 
 .website {
@@ -55,5 +52,3 @@
         }
     }
 }
-
-// EOF


### PR DESCRIPTION
To comply with the basic licence GPL-3.0 guidelines, this pull request removes the old licence information from the LESS file headers ([see discussion](https://github.com/slub/dfg-viewer/pull/230#discussion_r1273563638)). In addition, the obsolete and unnecessary `//EOF` statement at the end of the LESS and JS files is removed.