### PR TITLE
Fix two details in the calendar view of newspapers

### DIFF
--- a/Resources/Private/Less/components/newspapers.less
+++ b/Resources/Private/Less/components/newspapers.less
@@ -231,7 +231,10 @@
                 padding: 30px;
                 width: 50%;
                 float: left;
-                overflow: hidden;
+                // does not display the link box for day in last line of a month completely
+                // overflow: hidden;
+                // displays the link box for the day in the last line of a month completely
+                overflow: inherit;
                 table {
                     width: 100%;
                     margin: 0;

--- a/Resources/Private/Less/components/newspapers.less
+++ b/Resources/Private/Less/components/newspapers.less
@@ -142,6 +142,8 @@
                         }
                         ul.issues {
                             opacity: 1;
+                            // In the calendar view, with an open day, display date above the underlying text completely.
+                            z-index: 100;
                             .transform(scaleY(1));
                             li {
                                 margin: 10px 0;


### PR DESCRIPTION
Fix two details in the calendar view from newspapers:
- with an open day, display date above the underlaying text completely
- display the link box for the day in the last line of a month completely

# Details

When you click on a day in the calendar view of a newspaper, an overlay box with a date appears. The text underneath partially covers the date (at the bottom), this is corrected.

before:
![image](https://github.com/slub/dfg-viewer/assets/4037984/3a5f7230-bed3-4252-8574-746a23968fbe)

after:
![image](https://github.com/slub/dfg-viewer/assets/4037984/57a588cc-6189-4651-ae48-6877353fcf70)

If the day is at the end of the month (last row of the table) the overlay box is only partially displayed, this is corrected.

before:
![image](https://github.com/slub/dfg-viewer/assets/4037984/70258ef0-1822-4cf8-8ffb-994b3cb6cb63)

after:
![image](https://github.com/slub/dfg-viewer/assets/4037984/1dffe18e-2c25-46d2-b5ff-e123fea2d219)
