### PR TITLE
Ignore this error until Kitodo.Presentation is not updated

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     ignoreErrors:
+            - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Model\\Document::getCurrentDocument\(\)\.#'
             - '#Parameter \#1 \$documentId of method Kitodo\\Dlf\\Controller\\AbstractController::loadDocument\(\) expects int, array given\.#'
     level: 5
     paths:


### PR DESCRIPTION
This method is already renamed in master but not yet in 4.x branch.