### PR TITLE
Fix call to `\Kitodo\Dlf\Middleware\SruMiddleware`

### DIFF
--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -26,7 +26,7 @@
 return [
     'frontend' => [
         'dfgviewer/sru' => [
-            'target' => \Kitodo\Dlf\Middleware\SruMiddleware::class,
+            'target' => Slub\Dfgviewer\Middleware\SruMiddleware::class,
             'after' => [
                 'typo3/cms-frontend/prepare-tsfe-rendering'
             ]


### PR DESCRIPTION
I'm not sure if this has any downsides, nor did I looked deeper why there is a false call, but this PR fixes the issue in #254