### PR TITLE
Remove dependency to slub_digitalcollections

### DIFF
--- a/Classes/ViewHelpers/CalcViewHelper.php
+++ b/Classes/ViewHelpers/CalcViewHelper.php
@@ -1,0 +1,83 @@
+<?php
+namespace Slub\Dfgviewer\ViewHelpers;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Alexander Bigga <typo3@slub-dresden.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * ViewHelper to calculate two integers
+ *
+ * # Example: Basic example
+ * <code>
+ * <si:calc val1="1" val2="2" operator="+" />
+ * </code>
+ * <output>
+ * Will output "3"
+ * </output>
+ *
+ * @package TYPO3
+ */
+class CalcViewHelper extends AbstractViewHelper
+{
+    /**
+     * Initialize arguments.
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('val1', 'integer', 'first value', true);
+        $this->registerArgument('val2', 'integer', 'second value', true);
+        $this->registerArgument('operator', 'string', 'operator', false, '+');
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $val1 = $arguments['val1'];
+        $val2 = $arguments['val2'];
+        $operator = $arguments['operator'];
+
+        switch ($operator) {
+          case '+': $result = (int)$val1 + (int)$val2;
+                    break;
+          case '-': $result = (int)$val1 - (int)$val2;
+                    break;
+          case '*': $result = (int)$val1 * (int)$val2;
+                    break;
+          case '/': $result = (int)((int)$val1 / (int)$val2);
+                    break;
+        }
+
+        return $result;
+    }
+}

--- a/Classes/ViewHelpers/ProviderLogoCachedViewHelper.php
+++ b/Classes/ViewHelpers/ProviderLogoCachedViewHelper.php
@@ -1,0 +1,87 @@
+<?php
+namespace Slub\Dfgviewer\ViewHelpers;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2019 Alexander Bigga <typo3@slub-dresden.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * ViewHelper to get the provider logo from cache
+ *
+ * @package TYPO3
+ */
+class ProviderLogoCachedViewHelper extends AbstractViewHelper
+{
+    /**
+     * Initialize arguments.
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('logo', 'string', 'URI of the provider logo', true);
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $logoUrl = $arguments['logo'];
+        // is valid uri?
+        if (GeneralUtility::isValidUrl($logoUrl)) {
+            // calculate cache identifier
+            $logoInfo = pathinfo($logoUrl);
+            $cacheIdentifier = md5($logoUrl) . '.' . $logoInfo['extension'];
+            $logoFile = Environment::getPublicPath() . '/typo3temp/assets/images/' . $cacheIdentifier;
+            // if file exists and is not too old - take it
+            if (file_exists($logoFile)) {
+                // if not older than one day:
+                if ((time() - filemtime($logoFile) < 86400)) {
+                    return $cacheIdentifier;
+                }
+            }
+
+            // file not present or too old --> fetch new
+            $context = stream_context_create(array(
+                'http' => array(
+                    'timeout' => 10
+                    )
+                )
+            );
+            $logo = @file_get_contents($logoUrl, false, $context, 0, 1024*100);
+            // Save value in cache
+            if ($logo) {
+                GeneralUtility::writeFile($logoFile, $logo);
+                return $cacheIdentifier;
+            }
+        }
+        return FALSE;
+    }
+}

--- a/Classes/ViewHelpers/XpathViewHelper.php
+++ b/Classes/ViewHelpers/XpathViewHelper.php
@@ -1,0 +1,157 @@
+<?php
+namespace Slub\Dfgviewer\ViewHelpers;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Alexander Bigga <typo3@slub-dresden.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+use Kitodo\Dlf\Common\MetsDocument;
+use Kitodo\Dlf\Domain\Model\Document;
+use Kitodo\Dlf\Domain\Repository\DocumentRepository;
+
+/**
+ * ViewHelper to get page info
+ *
+ * # Example: Basic example
+ * <code>
+ * <si:pageInfo page="123">
+ *	<span>123</span>
+ * </code>
+ * <output>
+ * Will output the page record
+ * </output>
+ *
+ * @package TYPO3
+ */
+class XpathViewHelper extends AbstractViewHelper
+{
+    /**
+     * Initialize arguments.
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('xpath', 'string', 'Xpath Expression', true);
+        $this->registerArgument('htmlspecialchars', 'boolean', 'Use htmlspecialchars() on the found result.', false, true);
+        $this->registerArgument('returnArray', 'boolean', 'Return results in an array instead of string.', false, false);
+    }
+
+    /**
+     * documentRepository
+     *
+     * @var DocumentRepository
+     */
+    protected static $documentRepository = null;
+
+    /**
+     * Render the supplied DateTime object as a formatted date.
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     */
+    public static function renderStatic(
+      array $arguments,
+      \Closure $renderChildrenClosure,
+      RenderingContextInterface $renderingContext
+    ) {
+        $xpath = $arguments['xpath'];
+        $htmlspecialchars = $arguments['htmlspecialchars'];
+        $returnArray = $arguments['returnArray'];
+
+        $parameters = [];
+
+        $parametersSet = GeneralUtility::_GPmerged('set');
+        $parametersDlf = GeneralUtility::_GPmerged('tx_dlf');
+        if (isset($parametersSet['mets']) && GeneralUtility::isValidUrl($parametersSet['mets'])) {
+            $parameters['location'] = $parametersSet['mets'];
+        } else if (isset($parametersDlf['id'])) {
+            if (MathUtility::canBeInterpretedAsInteger($parametersDlf['id'])) {
+                $parameters['id'] = $parametersDlf['id'];
+            } else if (GeneralUtility::isValidUrl($parametersDlf['id'])) {
+                $parameters['location'] = $parametersDlf['id'];
+            }
+        } else if (isset($parametersDlf['recordId'])) {
+            $parameters['recordId'] = $parametersDlf['recordId'];
+        }
+
+        $document = self::getDocumentRepository()->findOneByParameters($parameters);
+
+        if ($document === null || $document->getCurrentDocument() === null || !($document->getCurrentDocument() instanceof MetsDocument)) {
+            return;
+        }
+        $currentDocument = $document->getCurrentDocument();
+        $currentDocument->mets->registerXPathNamespace('mets', 'http://www.loc.gov/METS/');
+        $currentDocument->mets->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
+        $currentDocument->mets->registerXPathNamespace('dv', 'http://dfg-viewer.de/');
+        $currentDocument->mets->registerXPathNamespace('slub', 'http://slub-dresden.de/');
+
+        $result = $currentDocument->mets->xpath($xpath);
+
+        if (is_array($result)) {
+          foreach ($result as $row) {
+            if ($returnArray) {
+              $output[] = $htmlspecialchars ? htmlspecialchars(trim($row)) : trim($row);
+            } else {
+              $output .= $htmlspecialchars ? htmlspecialchars(trim($row)) : trim($row) . ' ';
+            }
+          }
+        } else {
+          if ($returnArray) {
+            $output[] = $htmlspecialchars ? htmlspecialchars(trim($row)) : trim($row);
+          } else {
+            $output = $htmlspecialchars ? htmlspecialchars(trim($row)) : trim($row);
+          }
+        }
+
+        if (! $returnArray) {
+            return trim($output);
+        } else {
+            return $output;
+        }
+    }
+
+
+    /**
+     * Initialize the documentRepository
+     *
+     * return documentRepository
+     */
+    private static function getDocumentRepository()
+    {
+        if (null === static::$documentRepository) {
+            $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+            static::$documentRepository = $objectManager->get(
+                DocumentRepository::class
+            );
+        }
+
+        return static::$documentRepository;
+    }
+
+}

--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -40,6 +40,45 @@ plugin.tx_dlf {
 }
 
 # --------------------------------------------------------------------------------------------------------------------
+# search
+# --------------------------------------------------------------------------------------------------------------------
+
+plugin.tx_dlf_search < tt_content.list.20.dlf_search
+
+lib.kitodo.fulltext.search < plugin.tx_dlf_search
+lib.kitodo.fulltext.search {
+    view {
+		templateRootPaths {
+			10 = EXT:slub_digitalcollections/Resources/Private/Plugins/Kitodo/Templates/Fulltext
+		}
+	}
+    settings {
+        // UID of dlfCore0
+        solrcore = {$config.kitodo.solr.core}
+        limit = {$config.kitodo.solr.searchLimit}
+        // we activate fulltext here and search only in fulltext (see template)
+        fulltext = 1
+        // search only in current document
+        searchIn = document
+        // doesn't work due to javascript inclusion of autocomplete in header
+        suggest = 0
+        targetPid = {$config.kitodo.listView}
+        // this feature doesn't work in our case. It always jumps to page 1
+        showSingleResult = 0
+    }
+}
+
+# --------------------------------------------------------------------------------------------------------------------
+# collections
+# --------------------------------------------------------------------------------------------------------------------
+
+
+# --------------------------------------------------------------------------------------------------------------------
+# listview
+# --------------------------------------------------------------------------------------------------------------------
+
+
+# --------------------------------------------------------------------------------------------------------------------
 # metadata
 # --------------------------------------------------------------------------------------------------------------------
 plugin.tx_dlf_metadata < tt_content.list.20.dlf_metadata
@@ -173,6 +212,29 @@ plugin.tx_dlf_imagemanipulationtool {
     }
 }
 
+plugin.tx_dlf_fulltextdownloadtool < plugin.tx_dlf_toolbox
+plugin.tx_dlf_fulltextdownloadtool {
+    settings {
+        tools = fulltextdownloadtool
+    }
+}
+
+plugin.tx_dlf_searchindocumenttool < plugin.tx_dlf_toolbox
+plugin.tx_dlf_searchindocumenttool {
+    settings {
+        tools = searchindocumenttool
+        idInputName = tx_dlf[id]
+        pidInputName = tx_dlf[pid]
+        queryInputName = tx_dlf[query]
+        startInputName = tx_dlf[start]
+        pageInputName = tx_dlf[page]
+        highlightWordInputName = tx_dlf[highlight_word]
+        encryptedInputName = tx_dlf[encrypted]
+        // UID of dlfCore0
+        solrcore = {$config.kitodo.solr.core}
+    }
+}
+
 plugin.tx_dlf_pdfdownloadtool < plugin.tx_dlf_toolbox
 plugin.tx_dlf_pdfdownloadtool {
     settings {
@@ -193,31 +255,79 @@ plugin.tx_dlf_audioplayer {
 # --------------------------------------------------------------------------------------------------------------------
 # newspaper navigation
 # --------------------------------------------------------------------------------------------------------------------
+lib.kitodo.newspaper.years < tt_content.list.20.dlf_calendar
+lib.kitodo.newspaper.years {
+    switchableControllerActions {
+        Calendar {
+            1 = years
+        }
+    }
+    settings {
+        targetPid = {$config.kitodo.pageView}
+    }
+}
 
-[getDocumentType("{$config.storagePid}") == "ephemera" or getDocumentType("{$config.storagePid}") == "newspaper"]
+lib.kitodo.newspaper.calendar < tt_content.list.20.dlf_calendar
+lib.kitodo.newspaper.calendar {
+    switchableControllerActions {
+        Calendar {
+            1 = calendar
+        }
+    }
+    settings {
+        targetPid = {$config.kitodo.pageView}
+        showEmptyMonths = 0
+    }
+}
+
+[getDocumentType({$config.kitodo.storagePid}) === 'ephemera' or getDocumentType({$config.kitodo.storagePid}) === 'newspaper']
 page.10.variables {
   isNewspaper = TEXT
   isNewspaper.value = newspaper_anchor
 }
 [END]
 
-[getDocumentType("{$config.storagePid}") == "year"]
+[getDocumentType({$config.kitodo.storagePid}) === 'year']
 page.10.variables {
   isNewspaper = TEXT
   isNewspaper.value = newspaper_year
 }
+# in year files, the full year is only in mets_orderlabel - not year field in Kitodo.Presentation 3.0
+page.2 {
+    # if year is set
+    yearDate {
+      cObject = TEXT
+      cObject {
+        dataWrap = DB:tx_dlf_documents:{GP:tx_dlf|id}:mets_orderlabel
+        wrap3={|}
+        insertData=1
+      }
+    }
+}
+page.2.postTitle.cObject {
+    30 = TEXT
+    30 {
+        data = register:yearDate
+        required = 1
+        noTrimWrap = |: ||
+    }
+}
 [END]
 
-[getDocumentType("{$config.storagePid}") == "issue"]
+[getDocumentType({$config.kitodo.storagePid}) === 'issue']
 page.10.variables {
   isNewspaper = TEXT
   isNewspaper.value = newspaper_issue
 }
-[END]
-
-[getDocumentType("{$config.storagePid}") == "object"]
-page.10.variables {
-  isObject3D = TEXT
-  isObject3D.value = object
+# The issue has YYYY-MM-DD as dateformat for the publishing date. We can format it in a localized format:
+page.2.postTitle.cObject {
+    30 = TEXT
+    30 {
+        data = register:yearDate
+        required = 1
+        strtotime = 1
+        strftime = %d.%m.%Y
+        noTrimWrap = |: ||
+    }
 }
 [END]

--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -31,11 +31,9 @@ plugin.tx_dlf {
     }
 	view {
 		partialRootPaths {
-			10 = EXT:slub_digitalcollections/Resources/Private/Plugins/Kitodo/Partials
 			20 = EXT:dfgviewer/Resources/Private/Plugins/Kitodo/Partials
 		}
 		templateRootPaths {
-			10 = EXT:slub_digitalcollections/Resources/Private/Plugins/Kitodo/Templates
 			20 = EXT:dfgviewer/Resources/Private/Plugins/Kitodo/Templates
 		}
 	}

--- a/Resources/Private/Layouts/KitodoPage.html
+++ b/Resources/Private/Layouts/KitodoPage.html
@@ -1,11 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 	  xmlns:dv="http://typo3.org/ns/Slub/Dfgviewer/ViewHelpers"
-	  xmlns:dc="http://typo3.org/ns/Slub/SlubDigitalcollections/ViewHelpers"
 	  data-namespace-typo3-fluid="true"
       lang="en">
 
 <dv:titleTag
-	title="{dc:xpath(xpath:'(//mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:nonSort | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:title | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:partNumber | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:partName)')}"
+	title="{dv:xpath(xpath:'(//mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:nonSort | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:title | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:partNumber | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type=\'alternative\')]/mods:partName)')}"
 />
 
 <div class="main-wrapper">

--- a/Resources/Private/Partials/PageView.html
+++ b/Resources/Private/Partials/PageView.html
@@ -1,6 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-  xmlns:dv="http://typo3.org/ns/Slub/Dfgviewer/ViewHelpers"
-  xmlns:dc="http://typo3.org/ns/Slub/SlubDigitalcollections/ViewHelpers" data-namespace-typo3-fluid="true" lang="en">
+      xmlns:dv="http://typo3.org/ns/Slub/Dfgviewer/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+      lang="en">
 
 <f:section name="PageView">
 <div class="document-view">
@@ -59,40 +60,40 @@
         <div class="provider">
           <f:if condition="{settings.showProviderLogo}">
             <ul>
-              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerLogo)[1]\')}',
-                logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]\')}',
-                logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]\',
+              <f:alias map="{logoUrl: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerLogo)[1]\')}',
+                logoTitle: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:owner)[1]\')}',
+                logoUri: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:ownerSiteURL)[1]\',
                 htmlspecialchars:\'FALSE\')}'}">
-                <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
+                <f:if condition="{dv:providerLogoCached(logo:'{logoUrl}')}">
                   <li>
                     <f:link.external uri="{logoUri}" title="{logoTitle}">
-                      <img src="/typo3temp/assets/images/{dc:providerLogoCached(logo:'{logoUrl}')}" title="{logoTitle}"
+                      <img src="/typo3temp/assets/images/{dv:providerLogoCached(logo:'{logoUrl}')}" title="{logoTitle}"
                         alt="Logo von {logoTitle}" />
                     </f:link.external>
                   </li>
                 </f:if>
               </f:alias>
-              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorLogo)[1]\')}',
-                logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregator)[1]\')}',
-                logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorSiteURL)[1]\',
+              <f:alias map="{logoUrl: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorLogo)[1]\')}',
+                logoTitle: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregator)[1]\')}',
+                logoUri: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:aggregatorSiteURL)[1]\',
                 htmlspecialchars:\'FALSE\')}'}">
-                <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
+                <f:if condition="{dv:providerLogoCached(logo:'{logoUrl}')}">
                   <li>
                     <f:link.external uri="{logoUri}" title="{logoTitle}">
-                      <img src="/typo3temp/assets/images/{dc:providerLogoCached(logo:'{logoUrl}')}" title="{logoTitle}"
+                      <img src="/typo3temp/assets/images/{dv:providerLogoCached(logo:'{logoUrl}')}" title="{logoTitle}"
                         alt="Logo von {logoTitle}" />
                     </f:link.external>
                   </li>
                 </f:if>
               </f:alias>
-              <f:alias map="{logoUrl: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorLogo)[1]\')}',
-                logoTitle: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsor)[1]\')}',
-                logoUri: '{dc:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorSiteURL)[1]\',
+              <f:alias map="{logoUrl: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorLogo)[1]\')}',
+                logoTitle: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsor)[1]\')}',
+                logoUri: '{dv:xpath(xpath:\'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\"DVRIGHTS\"]/mets:xmlData/dv:rights/dv:sponsorSiteURL)[1]\',
                 htmlspecialchars:\'FALSE\')}'}">
-                <f:if condition="{dc:providerLogoCached(logo:'{logoUrl}')}">
+                <f:if condition="{dv:providerLogoCached(logo:'{logoUrl}')}">
                   <li>
                     <f:link.external uri="{logoUri}" title="{logoTitle}">
-                      <img src="/typo3temp/assets/images/{dc:providerLogoCached(logo:'{logoUrl}')}" title="{logoTitle}"
+                      <img src="/typo3temp/assets/images/{dv:providerLogoCached(logo:'{logoUrl}')}" title="{logoTitle}"
                         alt="Logo von {logoTitle}" />
                     </f:link.external>
                   </li>
@@ -105,13 +106,13 @@
             <dt class="tx-dlf-title">Titel</dt>
             <dd class="tx-dlf-title">
               <a href="#">
-                <dc:xpath
+                <dv:xpath
                   xpath='(//mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type="alternative")]/mods:nonSort | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type="alternative")]/mods:title | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type="alternative")]/mods:partNumber | //mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:titleInfo[not(@type="alternative")]/mods:partName)' />
               </a>
             </dd>
             <dt>Autor</dt>
             <dd>
-              <dc:xpath
+              <dv:xpath
                 xpath='(//mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:relatedItem[@type="host"]/mods:name[//mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods/mods:name/mods:role/mods:roleTerm[@authority="marcrelator"][@type="code"]="aut"]/mods:displayForm)[1]' />
             </dd>
           </dl>
@@ -123,10 +124,10 @@
             <ul>
               <li>
                 <f:if
-                  condition="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:presentation)[1]')}">
+                  condition="{dv:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:presentation)[1]')}">
                   <f:then>
                     <f:link.external
-                      uri="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:presentation)[1]', htmlspecialchars:'FALSE')}"
+                      uri="{dv:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:presentation)[1]', htmlspecialchars:'FALSE')}"
                       class="local-presentation"
                       title="{f:translate(key:'provider.local_presentation', extensionName:'dfgviewer')}">
                       <f:translate key='provider.local_presentation' extensionName='dfgviewer' />
@@ -142,22 +143,22 @@
               </li>
               <f:for each="{0: '1', 1: '2', 2: '3'}" as="index">
                 <f:if
-                  condition="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]')}">
+                  condition="{dv:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]')}">
                   <li>
                     <f:if
-                      condition="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference/@linktext)[{index}]')}">
+                      condition="{dv:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference/@linktext)[{index}]')}">
                       <f:then>
                         <f:link.external
-                          uri="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]', htmlspecialchars:'FALSE')}"
+                          uri="{dv:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]', htmlspecialchars:'FALSE')}"
                           class="local-catalog"
                           title="{f:translate(key:'provider.local_catalogue', extensionName:'dfgviewer')}">
-                          <dc:xpath
+                          <dv:xpath
                             xpath='(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE="DVLINKS"]/mets:xmlData/dv:links/dv:reference/@linktext)[{index}]' />
                         </f:link.external>
                       </f:then>
                       <f:else>
                         <f:link.external
-                          uri="{dc:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]', htmlspecialchars:'FALSE')}"
+                          uri="{dv:xpath(xpath:'(//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:reference)[{index}]', htmlspecialchars:'FALSE')}"
                           class="local-catalog"
                           title="{f:translate(key:'provider.local_catalogue', extensionName:'dfgviewer')}">
                           <f:translate key='provider.local_catalogue' extensionName='dfgviewer' />
@@ -168,13 +169,13 @@
                 </f:if>
               </f:for>
               <f:if
-                condition="{dc:xpath(xpath:'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:ownerContact)[1]', htmlspecialchars:'FALSE')}">
+                condition="{dv:xpath(xpath:'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:ownerContact)[1]', htmlspecialchars:'FALSE')}">
                 <f:then>
                   <li>
                     <f:link.external
-                      uri="{dc:xpath(xpath:'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:ownerContact)[1]', htmlspecialchars: 'FALSE')}"
+                      uri="{dv:xpath(xpath:'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:ownerContact)[1]', htmlspecialchars: 'FALSE')}"
                       class="local-contact"
-                      title="{f:translate(key:'provider.email_provider', extensionName:'dfgviewer')} ({dc:xpath(xpath:'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:owner)[1]')})">
+                      title="{f:translate(key:'provider.email_provider', extensionName:'dfgviewer')} ({dv:xpath(xpath:'(//mets:amdSec/mets:rightsMD/mets:mdWrap[@OTHERMDTYPE=\'DVRIGHTS\']/mets:xmlData/dv:rights/dv:owner)[1]')})">
                       <f:translate key='provider.email_provider' extensionName='dfgviewer' />
                     </f:link.external>
                   </li>
@@ -207,7 +208,7 @@
                   <f:translate key="double.singlePageView" extensionName="dfgviewer" />
                 </f:link.page>
                 <f:link.page pageUid="{kitodoPageView}"
-                  additionalParams="{tx_dlf:{page:'{dc:calc(val1:\'{gp-page}\', val2:\'1\', operator:\'+\')}', double:'1', id:'{gp-id}', pagegrid:'0'}}"
+                  additionalParams="{tx_dlf:{page:'{dv:calc(val1:\'{gp-page}\', val2:\'1\', operator:\'+\')}', double:'1', id:'{gp-id}', pagegrid:'0'}}"
                   class="tx-dlf-navigation-doublePlusOne"
                   title="{f:translate(key:'double.RectoVerso', extensionName:'dfgviewer')}"><span>
                     <f:translate key="double.RectoVerso" extensionName="dfgviewer" />
@@ -224,7 +225,7 @@
             </f:if>
           </li>
           <f:if
-            condition="{dc:xpath(xpath:'(//mets:fileSec/mets:fileGrp[@USE=\'FULLTEXT\']/mets:file[1]/mets:FLocat/@xlink:href)[1]')}">
+            condition="{dv:xpath(xpath:'(//mets:fileSec/mets:fileGrp[@USE=\'FULLTEXT\']/mets:file[1]/mets:FLocat/@xlink:href)[1]')}">
             <li class="fulltext">
               <f:if condition="{gp-double} == 1">
                 <f:then>
@@ -251,7 +252,7 @@
           </f:if>
           <li class="grid">
             <f:if
-              condition="{dc:xpath(xpath:'(//mets:fileSec/mets:fileGrp[@USE=\'THUMBS\']/mets:file[1]/mets:FLocat/@xlink:href)[1]')}">
+              condition="{dv:xpath(xpath:'(//mets:fileSec/mets:fileGrp[@USE=\'THUMBS\']/mets:file[1]/mets:FLocat/@xlink:href)[1]')}">
               <f:then>
                 <f:if condition="{gp-pagegrid} == 1">
                   <f:then>
@@ -278,7 +279,7 @@
             </f:if>
           </li>
           <f:if
-            condition="{dc:xpath(xpath:'//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:sru')}">
+            condition="{dv:xpath(xpath:'//mets:amdSec/mets:digiprovMD/mets:mdWrap[@OTHERMDTYPE=\'DVLINKS\']/mets:xmlData/dv:links/dv:sru')}">
             <f:then>
               <li class="submenu search">
                 <a href="#" title="Search">Search</a>

--- a/Resources/Private/Plugins/Kitodo/Templates/Fulltext/Search/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Fulltext/Search/Main.html
@@ -1,0 +1,51 @@
+<f:comment>
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+</f:comment>
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:form action="search" controller="Search" name="searchParameter" method="get">
+
+    <label for="tx-dlf-search-query">
+        <f:if condition="{lastSearch.query}">
+            <f:then>{lastSearch.query -> f:format.htmlspecialchars()}</f:then>
+            <f:else><f:translate key="search.query"/></f:else>
+        </f:if>
+    </label>
+
+    <f:form.textfield id="tx-dlf-search-query" property="query" value="{lastSearch.query}" />
+
+    <f:form.submit value="{f:translate(key: 'search.submit')}" />
+
+    <!-- Fulltext switch -->
+    <f:form.hidden property="fulltext" value="1" />
+
+    <f:if condition="{settings.searchIn} == 'collection' || {settings.searchIn} == 'all'">
+        <f:form.hidden property="collections" value="{settings.collections}" />
+    </f:if>
+
+    <f:if condition="{settings.searchIn} == 'document' || {settings.searchIn} == 'all'">
+        <f:form.hidden property="documentId" value="{currentDocument.uid}" />
+        <input type="hidden" name="tx_dlf[id]" value="{currentDocument.uid}" />
+    </f:if>
+
+    <!-- Add current collection if using on collection single view -->
+    <f:if condition="{lastSearch.collection}">
+        <f:then>
+            <input type="hidden" name="collection" value="{lastSearch.collection}" />
+        </f:then>
+    </f:if>
+
+</f:form>
+
+
+
+</html>

--- a/Resources/Private/Plugins/Kitodo/Templates/Navigation/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Navigation/Main.html
@@ -1,0 +1,229 @@
+<f:comment>
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+</f:comment>
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:comment>Render all navigation features in the given order.</f:comment>
+<f:for each="{features}" key="feature" as="enabled">
+    <f:if condition="{feature}">
+        <f:render section="render.{feature}" arguments="{_all}"/>
+    </f:if>
+</f:for>
+
+<f:section name="render.doublepage">
+    <f:if condition="{numPages} > 0">
+        <f:then>
+            <f:if condition="{viewData.requestData.double}">
+                <f:then>
+                    <div class="tx-dlf-navigation-double">
+                        <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[double]':'0'}">
+                            <f:translate key="doublePageOn"/>
+                        </f:link.action>
+                    </div>
+                    <div class="tx-dlf-navigation-double+">
+                        <f:if condition="{viewData.requestData.double} && ({viewData.requestData.page} < {numPages})">
+                            <f:then>
+                                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1}'}">
+                                    <f:translate key="doublePage+1"/>
+                                </f:link.action>
+                            </f:then>
+                            <f:else>
+                                <span title="{f:translate(key: 'doublePage+1')}">
+                                    <f:translate key="doublePage+1"/>
+                                </span>
+                            </f:else>
+                        </f:if>
+                    </div>
+                </f:then>
+                <f:else>
+                    <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[double]':'1'}">
+                        <f:translate key="doublePageOn"/>
+                    </f:link.action>
+                </f:else>
+            </f:if>
+        </f:then>
+        <f:else>
+            <div class="tx-dlf-navigation-double">
+                <span title="{f:translate(key: 'doublePageOn')}">
+                    <f:translate key="doublePageOn"/>
+                </span>
+            </div>
+        </f:else>
+    </f:if>
+</f:section>
+
+<f:section name="render.pageFirst">
+    <div class="backs">
+        <span class="first">
+            <f:if condition="{viewData.requestData.page} > 1">
+                <f:then>
+                    <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'1'}" class="first" >
+                        <f:translate key="firstPage"/>
+                    </f:link.action>
+                </f:then>
+                <f:else>
+                    <span class="first" title="{f:translate(key: 'firstPage')}">
+                        <f:translate key="firstPage"/>
+                    </span>
+                </f:else>
+            </f:if>
+        </span>
+</f:section>
+
+<f:section name="render.pageBack">
+    <span class="rwnd">
+        <f:if condition="{viewData.requestData.page} > {pageSteps}">
+            <f:then>
+                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - pageSteps}'}">
+                    <f:translate key="backXPages" arguments="{0: '{pageSteps}'}"/>
+                </f:link.action>
+            </f:then>
+            <f:else>
+                <span title="{f:translate(key: 'backXPages', arguments: '{0: pageSteps}')}">
+                    <f:translate key="backXPages" arguments="{0: '{pageSteps}'}"/>
+                </span>
+            </f:else>
+        </f:if>
+    </span>
+</f:section>
+
+<f:section name="render.pageStepBack">
+        <span class="prev">
+            <f:if condition="{viewData.requestData.page} > {viewData.requestData.double + 1}">
+                <f:then>
+                    <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - 1 - viewData.requestData.double}'}">
+                        <f:translate key="prevPage"/>
+                    </f:link.action>
+                </f:then>
+                <f:else>
+                    <span title="{f:translate(key: 'prevPage')}">
+                        <f:translate key="prevPage"/>
+                    </span>
+                </f:else>
+            </f:if>
+        </span>
+    </div>
+</f:section>
+
+<f:section name="render.pageselect">
+    <li class="pages">
+        <form method="get" action="{f:uri.page(pageUid='{viewData.requestData.pageUid}')}">
+            <f:if condition="{viewData.requestData.id}">
+                <f:form.hidden name="tx_dlf[id]" value="{viewData.requestData.id}"/>
+            </f:if>
+            <f:if condition="{viewData.requestData.recordId}">
+                <f:form.hidden name="tx_dlf[recordId]" value="{viewData.requestData.recordId}"/>
+            </f:if>
+            <f:if condition="{viewData.requestData.double}">
+                <f:form.hidden name="tx_dlf[double]" value="{viewData.requestData.double}"/>
+            </f:if>
+            <label for="tx-dlf-page-{viewData.uniqueId}">
+                <f:translate key="selectPage"/>
+            </label>
+            <f:form.select id="tx-dlf-page-{viewData.uniqueId}" name="tx_dlf[page]"
+                options="{pageOptions}"
+                value="{viewData.requestData.page}"
+                additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
+            </f:form.select>
+        </form>
+    </li>
+</f:section>
+
+<f:section name="render.pageForward">
+    <div class="fwds">
+        <span class="next">
+            <f:if condition="{viewData.requestData.page + viewData.requestData.double} < {numPages}">
+                <f:then>
+                    <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1 + viewData.requestData.double}'}">
+                        <f:translate key="nextPage"/>
+                    </f:link.action>
+                </f:then>
+                <f:else>
+                    <span title="{f:translate(key: 'nextPage')}">
+                        <f:translate key="nextPage"/>
+                    </span>
+                </f:else>
+            </f:if>
+        </span>
+</f:section>
+
+<f:section name="render.pageStepForward">
+        <span class="fwd">
+            <f:if condition="{viewData.requestData.page} <= {numPages - pageSteps}">
+                <f:then>
+                    <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + pageSteps}'}">
+                        <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
+                    </f:link.action>
+                </f:then>
+                <f:else>
+                    <span title="{f:translate(key: 'forwardXPages', arguments: '{0: pageSteps}')}">
+                        <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
+                    </span>
+                </f:else>
+            </f:if>
+        </span>
+</f:section>
+
+<f:section name="render.pageLast">
+        <span class="last">
+            <f:if condition="{viewData.requestData.page} < {numPages - viewData.requestData.double}">
+                <f:then>
+                    <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{numPages - viewData.requestData.double}'}">
+                        <f:translate key="lastPage"/>
+                    </f:link.action>
+                </f:then>
+                <f:else>
+                    <span title="{f:translate(key: 'lastPage'}">
+                        <f:translate key="lastPage"/>
+                    </span>
+                </f:else>
+            </f:if>
+        </span>
+    </div>
+</f:section>
+
+<f:section name="render.listview">
+        <div class="tx-dlf-navigation-listview">
+            <f:link.page pageUid="{settings.targetPid}">
+                <f:translate key="linkToList"/>
+            </f:link.page>
+        </div>
+</f:section>
+
+<f:section name="render.zoom">
+    <li class="zoom">
+        <a href="#" class="in" title="{f:translate(key: 'zoomIn')}" onclick="tx_dlf_viewer.map.zoomIn();">
+            <f:translate key="zoomIn"/>
+        </a>
+        <a href="#" class="out" title="{f:translate(key: 'zoomOut')}" onclick="tx_dlf_viewer.map.zoomOut();">
+            <f:translate key="zoomOut"/>
+        </a>
+        <a href="#" class="fullscreen" title="{f:translate(key: 'zoomFullscreen')}">
+            <f:translate key="zoomFullscreen"/>
+        </a>
+    </li>
+</f:section>
+
+<f:section name="render.rotation">
+    <li class="rotate">
+        <a href="#" class="rotate-left" title="{f:translate(key: 'rotateLeft')}" onclick="tx_dlf_viewer.map.rotateLeft();">
+            <f:translate key="rotateLeft"/>
+        </a>
+        <a href="#" class="rotate-right" title="{f:translate(key: 'rotateRight')}" onclick="tx_dlf_viewer.map.rotateRight();">
+            <f:translate key="rotateRight"/>
+        </a>
+        <a href="#" class="upend" title="{f:translate(key: 'rotateReset')}" onclick="tx_dlf_viewer.map.resetRotation();">
+            <f:translate key="rotateReset"/>
+        </a>
+    </li>
+</f:section>
+</html>

--- a/Resources/Private/Plugins/Kitodo/Templates/TableOfContents/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/TableOfContents/Main.html
@@ -12,6 +12,13 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<ul class="toc">
-    <f:render partial="TableOfContents/Children" arguments="{children: toc}"/>
-</ul>
+<div class="tx-dlf-toc tx-dlf-window tx-dlf-leftwin tx-dlf-open">
+    <div class="tx-dlf-minimize"></div>
+    <div class="tx-dlf-wincontainer">
+        <div class="tx-dlf-wincontent tx-dlf-scrollbar">
+            <ul class="toc">
+                <f:render partial="TableOfContents/Children" arguments="{children: toc}"/>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
+++ b/Resources/Private/Plugins/Kitodo/Templates/Toolbox/Main.html
@@ -1,0 +1,194 @@
+<f:comment>
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+</f:comment>
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:if condition="{renderAnnotationTool}">
+    <f:then>
+        <li>
+            <span class="tx-dlf-tools-annotations">
+                <f:if condition="{annotationTool}">
+                    <f:then>
+                        <a class="select switchoff" id="tx-dlf-tools-annotations" title="" data-dic="annotations-on:{f:translate(key: 'tools.annotation.on')};annotations-off:{f:translate(key: 'tools.annotation.off')}">
+                            <f:format.html>&nbsp;</f:format.html>
+                        </a>
+                    </f:then>
+                    <f:else>
+                        <span class="no-annotations">
+                            <f:translate key="tools.annotation.not-available"/>
+                        </span>
+                    </f:else>
+                </f:if>
+            </span>
+        </li>
+    </f:then>
+</f:if>
+
+<f:if condition="{renderImageManipulationTool}">
+    <f:then>
+        <span>
+            <span class="tx-dlf-tools-imagetools" id="tx-dlf-tools-imagetools"
+                    data-dic="imagemanipulation-on:{f:translate(key: 'tools.imagemanipulation.on')};imagemanipulation-off:{f:translate(key: 'tools.imagemanipulation.off')};reset:{f:translate(key: 'tools.imagemanipulation.reset')};saturation:{f:translate(key: 'tools.imagemanipulation.saturation')};hue:{f:translate(key: 'tools.imagemanipulation.hue')};contrast:{f:translate(key: 'tools.imagemanipulation.contrast')};brightness:{f:translate(key: 'tools.imagemanipulation.brightness')};invert:{f:translate(key: 'tools.imagemanipulation.invert')};parentContainer:{parentContainer}"
+                    title="{f:translate(key: 'tools.imagemanipulation.no-support')}">
+            </span>
+        </span>
+    </f:then>
+</f:if>
+
+<f:if condition="{renderImageDownloadTool} && {imageDownload}">
+    <f:then>
+        <li>
+            <span class="tx-dlf-tools-imagedownload">
+                <f:if condition="{double} === 0">
+                    <f:then>
+                        <f:link.external uri="{imageDownload.0.url}">
+                            <f:translate key="downloadSinglePage" /> {imageDownload.0.mimetypeLabel}
+                        </f:link.external>
+                    </f:then>
+                    <f:else>
+                        <f:link.external uri="{imageDownload.0.url}">
+                            <f:translate key="downloadLeftPage" /> {imageDownload.0.mimetypeLabel}
+                        </f:link.external>
+                        <f:if condition="{imageDownload.1}">
+                            <f:then>
+                                <span class="tx-dlf-tools-imagedownload">
+                                    <f:link.external uri="{imageDownload.1.url}">
+                                        <f:translate key="downloadRightPage" /> {imageDownload.1.mimetypeLabel}
+                                    </f:link.external>
+                                </span>
+                            </f:then>
+                        </f:if>
+                    </f:else>
+                </f:if>
+            </span>
+        </li>
+    </f:then>
+</f:if>
+
+<f:if condition="{renderFulltextTool}">
+    <f:then>
+        <f:if condition="{fulltext}">
+            <f:then>
+                <a class="select switchoff" id="tx-dlf-tools-fulltext" title=""
+                    data-dic="fulltext:{f:translate(key: 'tools.fulltext')};fulltext-loading:{f:translate(key: 'tools.fulltext.loading')};fulltext-on:{f:translate(key: 'tools.fulltext.on')};fulltext-off:{f:translate(key: 'tools.fulltext.off')};activate-full-text-initially:{activateFullTextInitially};full-text-scroll-element:{settings.fullTextScrollElement};search-hl-parameters:{settings.searchHlParameters}">
+                    &nbsp;
+                </a>
+            </f:then>
+            <f:else>
+                <span class="no-fulltext">
+                    <f:translate key="tools.fulltext.not-available"/>
+                </span>
+            </f:else>
+        </f:if>
+    </f:then>
+</f:if>
+
+<f:if condition="{renderFulltextDownloadTool}">
+    <f:then>
+        <li>
+            <f:if condition="{fulltextDownload}">
+                <f:then>
+                    <a href="#" id="tx-dlf-tools-fulltextdownload" class="download-fulltext"
+                        title="{f:translate(key: 'tools.fulltextdownload.download-current-page')}">
+                        <f:translate key="tools.fulltextdownload.download-current-page"/>
+                    </a>
+                </f:then>
+                <f:else>
+                    <span class="no-fulltext">
+                        <f:translate key="tools.fulltext.not-available"/>
+                    </span>
+                </f:else>
+            </f:if>
+        </li>
+    </f:then>
+</f:if>
+
+<f:if condition="{renderPdfDownloadTool}">
+    <f:then>
+        <f:if condition="{double} === 0">
+            <f:then>
+                <f:if condition="{pageLinks.0}">
+                    <li>
+                        <f:link.external uri="{pageLinks.0}" class="download-document">
+                            <f:translate key="downloadSinglePage" /> (PDF)
+                        </f:link.external>
+                    </li>
+                </f:if>
+            </f:then>
+            <f:else>
+                <f:if condition="{pageLinks.0}">
+                    <li>
+                        <f:link.external uri="{pageLinks.0}" class="download-document">
+                            <f:translate key="downloadLeftPage" /> (PDF)
+                        </f:link.external>
+                    </li>
+                </f:if>
+                <f:if condition="{pageLinks.1}">
+                    <li>
+                        <f:link.external uri="{pageLinks.1}" class="download-document">
+                            <f:translate key="downloadRightPage" /> (PDF)
+                        </f:link.external>
+                    </li>
+                </f:if>
+            </f:else>
+        </f:if>
+        <f:if condition="{workLink}">
+            <f:then>
+                <li>
+                    <f:link.external uri="{workLink}" class="download-document">
+                        <f:translate key="downloadWork"/> (PDF)
+                    </f:link.external>
+                </li>
+            </f:then>
+        </f:if>
+    </f:then>
+</f:if>
+
+<f:if condition="{renderSearchInDocumentTool} && {searchInDocument}">
+    <f:then>
+        <f:if condition="{settings.searchUrl}">
+            <f:then>
+                <f:variable name="actionUrl" value="{settings.searchUrl}" />
+            </f:then>
+            <f:else>
+                <f:variable name="actionUrl" value="{f:uri.page(pageUid='{viewData.pageUid}')}" />
+            </f:else>
+        </f:if>
+        <form class="tx-dlf-search-form" id="tx-dlf-search-in-document-form" action="{actionUrl}" method="get" enctype="multipart/form-data">
+            <div>
+                <label for="tx-dlf-search-in-document-query">
+                    <f:translate key="search.query"/>
+                </label>
+                <!-- Never change the @id of this input field! Otherwise search won't work! -->
+                <input type="text" id="tx-dlf-search-in-document-query" placeholder="{f:translate(key: 'tools.searchindocument.searchInDocument')}" name="{LABEL_QUERY_URL}" />
+                <input type="submit" id="tx-dlf-search-in-document-button" value="{f:translate(key: 'search.submit')}" onclick="resetStart();" />
+                <input type="hidden" id="tx-dlf-search-in-document-start" name="{searchInDocument.LABEL_START}" value="0" />
+                <input type="hidden" id="tx-dlf-search-in-document-id" name="{searchInDocument.LABEL_ID}" value="{searchInDocument.CURRENT_DOCUMENT}" />
+                <input type="hidden" id="tx-dlf-search-in-document-pid" name="{searchInDocument.LABEL_PID}" value="{viewData.pageUid}" />
+                <input type="hidden" id="tx-dlf-search-in-document-page" name="{searchInDocument.LABEL_PAGE_URL}" />
+                <input type="hidden" id="tx-dlf-search-in-document-highlight-word" name="{searchInDocument.LABEL_HIGHLIGHT_WORD}" />
+                <input type="hidden" id="tx-dlf-search-in-document-encrypted" name="{searchInDocument.LABEL_ENCRYPTED}" value="{searchInDocument.SOLR_ENCRYPTED}" />
+            </div>
+        </form>
+        <div id="tx-dlf-search-in-document-loading" style="display: none;"><f:translate key="tools.searchindocument.loading"/>...</div>
+        <div id="tx-dlf-search-in-document-clearing"><f:translate key="tools.searchindocument.deleteSearch"/>...</div>
+        <div id="tx-dlf-search-in-document-results"></div>
+        <div id="tx-dlf-search-in-document-labels" style="display:none;">
+            <span id="tx-dlf-search-in-document-label-next"><f:translate key="tools.searchindocument.next"/></span>
+            <span id="tx-dlf-search-in-document-label-previous"><f:translate key="tools.searchindocument.previous"/></span>
+            <span id="tx-dlf-search-in-document-label-page"><f:translate key="search.logicalPage"/></span>
+            <span id="tx-dlf-search-in-document-label-noresult"><f:translate key="tools.searchindocument.noresult"/></span>
+        </div>
+    </f:then>
+</f:if>
+
+</html>

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,7 @@
   "license": "GPL-3.0-or-later",
   "require": {
     "typo3/cms-core": "~9.5.31|^10.4",
-    "kitodo/presentation": "^4.0|dev-master",
-    "slub/slub-digitalcollections": "^3.0|dev-master"
+    "kitodo/presentation": "^4.0|dev-master"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
As proposed in #253, this draft intended to remove the dependencies on [slub_digitalcollections](https://github.com/slub/slub_digitalcollections).

I removed every trace and reference to the digitalcollections and where needed set new paths that lead within the repo. Than I copied missing files and updated some already existing. I tried to compare the commit dates and check it its working because I wasn't sure with the typoscript.
For future reference: digitalcollections state at this moment is following commit https://github.com/slub/slub_digitalcollections/commit/d511e7ebdddba4b9ea344eba5e5b311eb1e41c16. I did not copy the history. That exceeded my capabilities and I didn't want to spend hours going through and cleaning up commits. Hopefully this is ok. 
Btw. we should take a look at the licences, because some of the files have a copyright notice.

At this moment everthing I've tested is working fine. Which does obviously not mean that I didn't miss a lot or broke something!

**What I've tested:**
- Page View:
   - Navigation
   - UI: Links, Downloads, double and gridview
   - fulltext-container and overlay box
   - Toolbox: Rotation, Zoom, Fullscreen and imagemanipulation tools
- Search
- Collections

**What I've not tested:**
- 3D Viewer (is it working? If so, than give me an example)
- Calendar 
- ...??

**Whats not working:**
- ...??

Happy to get feedback and am looking forward to your corrections