### PR TITLE
Fix `ExtensionUtility::configurePlugin` calls

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,15 +25,12 @@ defined('TYPO3_MODE') or die();
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-// Register plugins.
-// ExtensionManagementUtility::addPItoST43('dfgviewer', 'Classes/Plugins/Sru/Sru.php', '_sru', 'list_type', TRUE);
-
 // Register Extbase plugins
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-    'Slub.Dfgviewer',
+    'Dfgviewer',
     'Uri',
     [
-        Uri::class => 'main'
+        \Slub\Dfgviewer\Controller\UriController::class => 'main'
     ],
     // non-cacheable actions
     [
@@ -41,10 +38,10 @@ defined('TYPO3_MODE') or die();
 );
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-    'Slub.Dfgviewer',
+    'Dfgviewer',
     'Sru',
     [
-        Sru::class => 'main'
+        \Slub\Dfgviewer\Controller\SruController::class => 'main'
     ],
     // non-cacheable actions
     [


### PR DESCRIPTION
Error:
`[NOTICE] request="7f793c25ff4d7" component="TYPO3.CMS.deprecations": Calling method TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin with argument $extensionName ("Slub.Dfgviewer") containing the vendor name ("Kitodo") is deprecated and will stop working in TYPO3 11.0. - {"file":"/var/www/html/public/typo3/sysext/extbase/Classes/Utility/ExtensionUtility.php","line":171}`

Since TYPO3 10 `$extensionName` should be called only as 'Dfgviewer'. This change is needed for upgrade to TYPO3 11.

Source: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html