### PR TITLE
Remove not needed double quotes for `$config.storagePid`

### DIFF
--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -206,28 +206,28 @@ plugin.tx_dlf_audioplayer {
 # newspaper navigation
 # --------------------------------------------------------------------------------------------------------------------
 
-[getDocumentType("{$config.storagePid}") == "ephemera" or getDocumentType("{$config.storagePid}") == "newspaper"]
+[getDocumentType({$config.storagePid}) == "ephemera" or getDocumentType({$config.storagePid}) == "newspaper"]
 page.10.variables {
   isNewspaper = TEXT
   isNewspaper.value = newspaper_anchor
 }
 [END]
 
-[getDocumentType("{$config.storagePid}") == "year"]
+[getDocumentType({$config.storagePid}) == "year"]
 page.10.variables {
   isNewspaper = TEXT
   isNewspaper.value = newspaper_year
 }
 [END]
 
-[getDocumentType("{$config.storagePid}") == "issue"]
+[getDocumentType({$config.storagePid}) == "issue"]
 page.10.variables {
   isNewspaper = TEXT
   isNewspaper.value = newspaper_issue
 }
 [END]
 
-[getDocumentType("{$config.storagePid}") == "object"]
+[getDocumentType({$config.storagePid}) == "object"]
 page.10.variables {
   isObject3D = TEXT
   isObject3D.value = object


### PR DESCRIPTION
According to example given in https://github.com/kitodo/kitodo-presentation/blob/63df5ebf49754a0bf9d4a0926f9398e573033b04/Configuration/ExpressionLanguage.php#L17 , the call shouldn't contain double quotes.
