### PR TITLE
Upgrade TYPO3 version to 11.5.36 and drop support for 9.5.31 in the composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   ],
   "license": "GPL-3.0-or-later",
   "require": {
-    "typo3/cms-core": "~9.5.31|^10.4",
+    "typo3/cms-core": "^10.4.36|^11.5.30",
     "kitodo/presentation": "^4.0|dev-master",
     "slub/slub-digitalcollections": "^3.0|dev-master"
   },


### PR DESCRIPTION
Tested with TYPO3 11.x -all functionalities of DFG Viewer work.