### PR TITLE
Assign correct html id to `fullTextScrollElement`

### DIFF
--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -174,7 +174,7 @@ plugin.tx_dlf_fulltexttool {
     settings {
         tools = fulltexttool
         activateFullTextInitially = 0
-        fullTextScrollElement = html, body
+        fullTextScrollElement = #tx-dlf-fulltextselection
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-presentation/issues/1151