### PR TITLE
Bump `typo3/cms-core` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   ],
   "license": "GPL-3.0-or-later",
   "require": {
-    "typo3/cms-core": "^10.4.36|^11.5.30",
+    "typo3/cms-core": "^10.4.36|^11.5",
     "kitodo/presentation": "^4.1|dev-master",
     "slub/slub-digitalcollections": "^3.0|dev-master"
   },


### PR DESCRIPTION
Allow typo3 core version up to the latest at the time ([11.5.34](https://get.typo3.org/version/11#get))