### PR TITLE
Fix calling registerPlugin with vendor name

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -5,13 +5,13 @@ defined('TYPO3_MODE') or die();
 $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['dfgviewer_uri'] = 'layout,select_key,pages,recursive';
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    'Slub.Dfgviewer',
+    'Dfgviewer',
     'Uri',
     'LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.search.title',
 );
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    'Slub.Dfgviewer',
+    'Dfgviewer',
     'SRU',
     'LLL:EXT:dfgviewer/Resources/Private/Language/locallang_be.xlf:plugins.sru.title',
 );


### PR DESCRIPTION
The first parameter $extensionName of method \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin used to contain the vendor name in the past.
As the vendor name does not have any effect at all, it's usage has been marked as deprecated.

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Deprecation-88995-CallingRegisterPluginWithVendorName.html