### PR TITLE
[BUGFIX] Remove overwriting of plugin settings with the default values

### DIFF
--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -61,7 +61,6 @@ plugin.tx_dlf_metadata {
 plugin.tx_dlf_pageview < tt_content.list.20.dlf_pageview
 plugin.tx_dlf_pageview {
     settings {
-        features =
         elementId = tx-dfgviewer-map
     }
 }
@@ -202,9 +201,6 @@ plugin.tx_dlf_pdfdownloadtool {
 # --------------------------------------------------------------------------------------------------------------------
 plugin.tx_dlf_audioplayer < tt_content.list.20.dlf_audioplayer
 plugin.tx_dlf_audioplayer {
-    settings {
-        elementId = tx-dlf-audio
-    }
 }
 
 # --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`elementId` is already the same in flex form inside Kitodo.Presentation
`features` shouldn't be empty, it is filled already in flex form

@ByteParty should I keep empty `plugin.tx_dlf_audioplayer {}` or should it be removed?