### PR TITLE
[MAINTENANCE] Deploy documentation to GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,17 +1,53 @@
-name: test documentation
+name: Documentation
+# Build and test documentation on pull_request and push event
+# If the git reference is the main branch, additionally build the documentation artifact and deploy it to GitHub Pages
 
 on: [ push, pull_request ]
 
 jobs:
-    tests:
-        name: documentation
+    build:
+        name: Build and test documentation
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-
             - name: Test if the documentation will render without warnings
               run: |
                   mkdir -p Documentation-GENERATED-temp \
-                  && docker run --rm --pull always -v $(pwd):/project \
-                     ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log
+                  && docker run --rm --pull always -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:latest configure --project-version="dev-master" ./Documentation \
+                  && docker run -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log
+            
+            - name: Rename root page
+              if: github.ref == 'refs/heads/main'  
+              run: mv ./Documentation-GENERATED-temp/Index.html ./Documentation-GENERATED-temp/index.html
+                     
+            - name: Upload artifact
+              if: github.ref == 'refs/heads/main'  
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: ./Documentation-GENERATED-temp/
+                     
+    deploy:
+      name: Deploy documentation to GitHub Pages
+    
+      # Add a dependency to the build job
+      needs: build
+
+      if: github.ref == 'refs/heads/main'
+  
+      # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+      permissions:
+        pages: write      # to deploy to Pages
+        id-token: write   # to verify the deployment originates from an appropriate source
+  
+      # Deploy to the github-pages environment
+      environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
+  
+      # Specify runner + deployment step
+      runs-on: ubuntu-latest
+      steps:
+        - name: Deploy to GitHub Pages
+          id: deployment
+          uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Building and testing of documentation are still triggered by push and pull_request event
- Additionally the documentation is deployed to GitHub Pages when `master` branch is changed