### PR TITLE
[MAINTENANCE]  Add metadata preset to data.xml

### DIFF
--- a/Initialisation/data.xml
+++ b/Initialisation/data.xml
@@ -55,44 +55,51 @@
                 </rec>
             </table>
             <table index="tx_dlf_formats" type="array">
-                <rec index="3" type="array">
-                    <uid>3</uid>
-                    <pid>0</pid>
+                <rec index="6" type="array">
+                    <uid>6</uid>
+                    <pid>3</pid>
                     <title>ALTO</title>
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="4" type="array">
-                    <uid>4</uid>
-                    <pid>0</pid>
-                    <title>IIIF1</title>
+                <rec index="7" type="array">
+                    <uid>7</uid>
+                    <pid>3</pid>
+                    <title>AUDIOMD</title>
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
                 <rec index="5" type="array">
                     <uid>5</uid>
-                    <pid>0</pid>
+                    <pid>3</pid>
+                    <title>IIIF1</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="4" type="array">
+                    <uid>4</uid>
+                    <pid>3</pid>
                     <title>IIIF2</title>
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="6" type="array">
-                    <uid>6</uid>
-                    <pid>0</pid>
+                <rec index="3" type="array">
+                    <uid>3</uid>
+                    <pid>3</pid>
                     <title>IIIF3</title>
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
                 <rec index="2" type="array">
                     <uid>2</uid>
-                    <pid>0</pid>
+                    <pid>3</pid>
                     <title>MODS</title>
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
                 <rec index="1" type="array">
                     <uid>1</uid>
-                    <pid>0</pid>
+                    <pid>3</pid>
                     <title>TEIHDR</title>
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
@@ -153,207 +160,351 @@
                 </rec>
             </table>
             <table index="tx_dlf_metadata" type="array">
-                <rec index="31" type="array">
-                    <uid>31</uid>
+                <rec index="87" type="array">
+                    <uid>87</uid>
                     <pid>3</pid>
-                    <title>Title</title>
+                    <title>Einheitssachtitel</title>
                     <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:32" type="array">
-                            <id>32</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:19" type="array">
-                            <id>19</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:45" type="array">
-                            <id>45</id>
+                        <element index="tx_dlf_metadataformat:79" type="array">
+                            <id>79</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="35" type="array">
-                    <uid>35</uid>
-                    <pid>3</pid>
-                    <title>Author</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:36" type="array">
-                            <id>36</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:11" type="array">
-                            <id>11</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="32" type="array">
-                    <uid>32</uid>
+                <rec index="86" type="array">
+                    <uid>86</uid>
                     <pid>3</pid>
                     <title>Titel</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:1" type="array">
-                            <id>1</id>
+                        <element index="tx_dlf_metadataformat:85" type="array">
+                            <id>85</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
-                        <element index="tx_dlf_metadataformat:23" type="array">
-                            <id>23</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="36" type="array">
-                    <uid>36</uid>
-                    <pid>3</pid>
-                    <title>Autor</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:2" type="array">
-                            <id>2</id>
+                        <element index="tx_dlf_metadataformat:91" type="array">
+                            <id>91</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="46" type="array">
-                    <uid>46</uid>
+                <rec index="85" type="array">
+                    <uid>85</uid>
                     <pid>3</pid>
-                    <title>Aufbewahrungsort</title>
+                    <title>Titelübersetzung</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:10" type="array">
-                            <id>10</id>
+                        <element index="tx_dlf_metadataformat:66" type="array">
+                            <id>66</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="45" type="array">
-                    <uid>45</uid>
+                <rec index="84" type="array">
+                    <uid>84</uid>
                     <pid>3</pid>
-                    <title>Settlement</title>
+                    <title>Serientitel</title>
                     <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:46" type="array">
-                            <id>46</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:12" type="array">
-                            <id>12</id>
+                        <element index="tx_dlf_metadataformat:58" type="array">
+                            <id>58</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="44" type="array">
-                    <uid>44</uid>
+                <rec index="83" type="array">
+                    <uid>83</uid>
                     <pid>3</pid>
-                    <title>Zeitraum</title>
+                    <title>Fassung</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:27" type="array">
-                            <id>27</id>
+                        <element index="tx_dlf_metadataformat:53" type="array">
+                            <id>53</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="43" type="array">
-                    <uid>43</uid>
+                <rec index="82" type="array">
+                    <uid>82</uid>
                     <pid>3</pid>
-                    <title>Period</title>
+                    <title>Autor:in</title>
                     <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:44" type="array">
-                            <id>44</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:48" type="array">
-                            <id>48</id>
+                        <element index="tx_dlf_metadataformat:86" type="array">
+                            <id>86</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="42" type="array">
-                    <uid>42</uid>
+                <rec index="81" type="array">
+                    <uid>81</uid>
                     <pid>3</pid>
-                    <title>Erstellungsdatum</title>
+                    <title>Regisseur:in</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:3" type="array">
-                            <id>3</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:26" type="array">
-                            <id>26</id>
+                        <element index="tx_dlf_metadataformat:69" type="array">
+                            <id>69</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="38" type="array">
-                    <uid>38</uid>
+                <rec index="80" type="array">
+                    <uid>80</uid>
                     <pid>3</pid>
-                    <title>Erscheinungsjahr (Gesamtheit)</title>
+                    <title>Filmemacher:in</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:25" type="array">
-                            <id>25</id>
+                        <element index="tx_dlf_metadataformat:68" type="array">
+                            <id>68</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="41" type="array">
-                    <uid>41</uid>
+                <rec index="79" type="array">
+                    <uid>79</uid>
                     <pid>3</pid>
-                    <title>Creation Date</title>
+                    <title>Komponist:in</title>
                     <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:42" type="array">
-                            <id>42</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:20" type="array">
-                            <id>20</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:46" type="array">
-                            <id>46</id>
+                        <element index="tx_dlf_metadataformat:78" type="array">
+                            <id>78</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="37" type="array">
-                    <uid>37</uid>
+                <rec index="78" type="array">
+                    <uid>78</uid>
                     <pid>3</pid>
-                    <title>Year of Publication (Parent)</title>
+                    <title>Librettist:in</title>
                     <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
+                        <element index="tx_dlf_metadataformat:76" type="array">
+                            <id>76</id>
+                            <table>tx_dlf_metadataformat</table>
                         </element>
-                        <element index="tx_dlf_metadata:38" type="array">
-                            <id>38</id>
-                            <table>tx_dlf_metadata</table>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="77" type="array">
+                    <uid>77</uid>
+                    <pid>3</pid>
+                    <title>Widmungsadressat:in</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:75" type="array">
+                            <id>75</id>
+                            <table>tx_dlf_metadataformat</table>
                         </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="76" type="array">
+                    <uid>76</uid>
+                    <pid>3</pid>
+                    <title>Schreiber:in</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:81" type="array">
+                            <id>81</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="75" type="array">
+                    <uid>75</uid>
+                    <pid>3</pid>
+                    <title>Bearbeiter:in</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:71" type="array">
+                            <id>71</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="74" type="array">
+                    <uid>74</uid>
+                    <pid>3</pid>
+                    <title>Interpret:in</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:70" type="array">
+                            <id>70</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="73" type="array">
+                    <uid>73</uid>
+                    <pid>3</pid>
+                    <title>Dirigent:in</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:67" type="array">
+                            <id>67</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="72" type="array">
+                    <uid>72</uid>
+                    <pid>3</pid>
+                    <title>Interviewpartner:in</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:65" type="array">
+                            <id>65</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="71" type="array">
+                    <uid>71</uid>
+                    <pid>3</pid>
+                    <title>Inhalt</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:57" type="array">
+                            <id>57</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="70" type="array">
+                    <uid>70</uid>
+                    <pid>3</pid>
+                    <title>Schlagwörter</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:56" type="array">
+                            <id>56</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="69" type="array">
+                    <uid>69</uid>
+                    <pid>3</pid>
+                    <title>Ortsbezug</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:55" type="array">
+                            <id>55</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="68" type="array">
+                    <uid>68</uid>
+                    <pid>3</pid>
+                    <title>Genre</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:80" type="array">
+                            <id>80</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="67" type="array">
+                    <uid>67</uid>
+                    <pid>3</pid>
+                    <title>PURL</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:73" type="array">
+                            <id>73</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="66" type="array">
+                    <uid>66</uid>
+                    <pid>3</pid>
+                    <title>SLUB-Katalog (PPN)</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:64" type="array">
+                            <id>64</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="65" type="array">
+                    <uid>65</uid>
+                    <pid>3</pid>
+                    <title>SWB (PPN)</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:63" type="array">
+                            <id>63</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="64" type="array">
+                    <uid>64</uid>
+                    <pid>3</pid>
+                    <title>Rechte-/Lizenzhinweis</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:72" type="array">
+                            <id>72</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="63" type="array">
+                    <uid>63</uid>
+                    <pid>3</pid>
+                    <title>Nutzungshinweis</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:62" type="array">
+                            <id>62</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="62" type="array">
+                    <uid>62</uid>
+                    <pid>3</pid>
+                    <title>Nutzungseinschränkung</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:52" type="array">
+                            <id>52</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="61" type="array">
+                    <uid>61</uid>
+                    <pid>3</pid>
+                    <title>Rechteinhaber:in</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:61" type="array">
+                            <id>61</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="60" type="array">
+                    <uid>60</uid>
+                    <pid>3</pid>
+                    <title>Angaben zum Original</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:83" type="array">
+                            <id>83</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="58" type="array">
+                    <uid>58</uid>
+                    <pid>3</pid>
+                    <title>Technische Metadaten</title>
+                    <relations index="rels" type="array">
                         <element index="tx_dlf_metadataformat:54" type="array">
                             <id>54</id>
                             <table>tx_dlf_metadataformat</table>
@@ -361,1110 +512,98 @@
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="34" type="array">
-                    <uid>34</uid>
-                    <pid>3</pid>
-                    <title>Autor (Gesamtheit)</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:24" type="array">
-                            <id>24</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="33" type="array">
-                    <uid>33</uid>
-                    <pid>3</pid>
-                    <title>Author (Parent)</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:34" type="array">
-                            <id>34</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:38" type="array">
-                            <id>38</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="30" type="array">
-                    <uid>30</uid>
-                    <pid>3</pid>
-                    <title>Gesamttitel</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:22" type="array">
-                            <id>22</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="29" type="array">
-                    <uid>29</uid>
-                    <pid>3</pid>
-                    <title>Parent Title</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:30" type="array">
-                            <id>30</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:43" type="array">
-                            <id>43</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="28" type="array">
-                    <uid>28</uid>
+                <rec index="57" type="array">
+                    <uid>57</uid>
                     <pid>3</pid>
                     <title>Kontext</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:21" type="array">
-                            <id>21</id>
+                        <element index="tx_dlf_metadataformat:89" type="array">
+                            <id>89</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="27" type="array">
-                    <uid>27</uid>
+                <rec index="56" type="array">
+                    <uid>56</uid>
                     <pid>3</pid>
-                    <title>Context</title>
+                    <title>RISM</title>
                     <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:28" type="array">
-                            <id>28</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:47" type="array">
-                            <id>47</id>
+                        <element index="tx_dlf_metadataformat:84" type="array">
+                            <id>84</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="26" type="array">
-                    <uid>26</uid>
+                <rec index="55" type="array">
+                    <uid>55</uid>
                     <pid>3</pid>
-                    <title>Strukturtyp</title>
-                    <relations index="rels" type="array"></relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="25" type="array">
-                    <uid>25</uid>
-                    <pid>3</pid>
-                    <title>Erscheinungsverlauf</title>
+                    <title>Werkverzeichnisnummer</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:28" type="array">
-                            <id>28</id>
+                        <element index="tx_dlf_metadataformat:74" type="array">
+                            <id>74</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="23" type="array">
-                    <uid>23</uid>
-                    <pid>3</pid>
-                    <title>Erscheinungsort (Gesamtheit)</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:29" type="array">
-                            <id>29</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="21" type="array">
-                    <uid>21</uid>
-                    <pid>3</pid>
-                    <title>Einrichtung</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:9" type="array">
-                            <id>9</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:35" type="array">
-                            <id>35</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="19" type="array">
-                    <uid>19</uid>
-                    <pid>3</pid>
-                    <title>Signatur</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:8" type="array">
-                            <id>8</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:34" type="array">
-                            <id>34</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="17" type="array">
-                    <uid>17</uid>
+                <rec index="54" type="array">
+                    <uid>54</uid>
                     <pid>3</pid>
                     <title>Band</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:33" type="array">
-                            <id>33</id>
+                        <element index="tx_dlf_metadataformat:101" type="array">
+                            <id>101</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="15" type="array">
-                    <uid>15</uid>
+                <rec index="53" type="array">
+                    <uid>53</uid>
                     <pid>3</pid>
                     <title>Ausgabe</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:32" type="array">
-                            <id>32</id>
+                        <element index="tx_dlf_metadataformat:100" type="array">
+                            <id>100</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="13" type="array">
-                    <uid>13</uid>
-                    <pid>3</pid>
-                    <title>Beschreibstoff</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:7" type="array">
-                            <id>7</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="11" type="array">
-                    <uid>11</uid>
-                    <pid>3</pid>
-                    <title>Blattzahl</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:6" type="array">
-                            <id>6</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="9" type="array">
-                    <uid>9</uid>
-                    <pid>3</pid>
-                    <title>Format</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:5" type="array">
-                            <id>5</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="3" type="array">
-                    <uid>3</uid>
-                    <pid>3</pid>
-                    <title>Erscheinungsort</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:4" type="array">
-                            <id>4</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="40" type="array">
-                    <uid>40</uid>
-                    <pid>3</pid>
-                    <title>Erscheinungsjahr</title>
-                    <relations index="rels" type="array"></relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="7" type="array">
-                    <uid>7</uid>
+                <rec index="52" type="array">
+                    <uid>52</uid>
                     <pid>3</pid>
                     <title>VD16</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:31" type="array">
-                            <id>31</id>
+                        <element index="tx_dlf_metadataformat:99" type="array">
+                            <id>99</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="6" type="array">
-                    <uid>6</uid>
-                    <pid>3</pid>
-                    <title>VD16</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:7" type="array">
-                            <id>7</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:49" type="array">
-                            <id>49</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="5" type="array">
-                    <uid>5</uid>
+                <rec index="51" type="array">
+                    <uid>51</uid>
                     <pid>3</pid>
                     <title>VD17</title>
                     <relations index="rels" type="array">
-                        <element index="tx_dlf_metadataformat:30" type="array">
-                            <id>30</id>
+                        <element index="tx_dlf_metadataformat:98" type="array">
+                            <id>98</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="4" type="array">
-                    <uid>4</uid>
+                <rec index="50" type="array">
+                    <uid>50</uid>
                     <pid>3</pid>
-                    <title>VD17</title>
+                    <title>Digitalisierung</title>
                     <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:5" type="array">
-                            <id>5</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:50" type="array">
-                            <id>50</id>
+                        <element index="tx_dlf_metadataformat:77" type="array">
+                            <id>77</id>
                             <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="1" type="array">
-                    <uid>1</uid>
-                    <pid>3</pid>
-                    <title>Document Type</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:26" type="array">
-                            <id>26</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="24" type="array">
-                    <uid>24</uid>
-                    <pid>3</pid>
-                    <title>Publication Run</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:25" type="array">
-                            <id>25</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:36" type="array">
-                            <id>36</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="22" type="array">
-                    <uid>22</uid>
-                    <pid>3</pid>
-                    <title>Place of Publication (Parent)</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:23" type="array">
-                            <id>23</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:42" type="array">
-                            <id>42</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="20" type="array">
-                    <uid>20</uid>
-                    <pid>3</pid>
-                    <title>Repository</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:21" type="array">
-                            <id>21</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:15" type="array">
-                            <id>15</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:40" type="array">
-                            <id>40</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="18" type="array">
-                    <uid>18</uid>
-                    <pid>3</pid>
-                    <title>Shelfmark</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:19" type="array">
-                            <id>19</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:18" type="array">
-                            <id>18</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:44" type="array">
-                            <id>44</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="16" type="array">
-                    <uid>16</uid>
-                    <pid>3</pid>
-                    <title>Volume</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:17" type="array">
-                            <id>17</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:39" type="array">
-                            <id>39</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="14" type="array">
-                    <uid>14</uid>
-                    <pid>3</pid>
-                    <title>Issue</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:15" type="array">
-                            <id>15</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:37" type="array">
-                            <id>37</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="12" type="array">
-                    <uid>12</uid>
-                    <pid>3</pid>
-                    <title>Material</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:13" type="array">
-                            <id>13</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:13" type="array">
-                            <id>13</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="10" type="array">
-                    <uid>10</uid>
-                    <pid>3</pid>
-                    <title>Leaves Count</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:11" type="array">
-                            <id>11</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:14" type="array">
-                            <id>14</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="8" type="array">
-                    <uid>8</uid>
-                    <pid>3</pid>
-                    <title>Physical Form</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:9" type="array">
-                            <id>9</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:17" type="array">
-                            <id>17</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="2" type="array">
-                    <uid>2</uid>
-                    <pid>3</pid>
-                    <title>Place of Publication</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:3" type="array">
-                            <id>3</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                        <element index="tx_dlf_metadataformat:16" type="array">
-                            <id>16</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="39" type="array">
-                    <uid>39</uid>
-                    <pid>3</pid>
-                    <title>Year of Publication</title>
-                    <relations index="rels" type="array">
-                        <element index="sys_language:1" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                        <element index="tx_dlf_metadata:40" type="array">
-                            <id>40</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-            </table>
-            <table index="tx_dlf_metadataformat" type="array">
-                <rec index="1" type="array">
-                    <uid>1</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="2" type="array">
-                    <uid>2</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="3" type="array">
-                    <uid>3</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="4" type="array">
-                    <uid>4</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="5" type="array">
-                    <uid>5</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="6" type="array">
-                    <uid>6</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="7" type="array">
-                    <uid>7</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="8" type="array">
-                    <uid>8</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="9" type="array">
-                    <uid>9</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="10" type="array">
-                    <uid>10</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="11" type="array">
-                    <uid>11</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="12" type="array">
-                    <uid>12</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="13" type="array">
-                    <uid>13</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="14" type="array">
-                    <uid>14</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="15" type="array">
-                    <uid>15</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="16" type="array">
-                    <uid>16</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="17" type="array">
-                    <uid>17</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="18" type="array">
-                    <uid>18</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="19" type="array">
-                    <uid>19</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="20" type="array">
-                    <uid>20</uid>
-                    <pid>3</pid>
-                    <title>TEIHDR</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:1" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="21" type="array">
-                    <uid>21</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="22" type="array">
-                    <uid>22</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="23" type="array">
-                    <uid>23</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="24" type="array">
-                    <uid>24</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="25" type="array">
-                    <uid>25</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="26" type="array">
-                    <uid>26</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="27" type="array">
-                    <uid>27</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="28" type="array">
-                    <uid>28</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="29" type="array">
-                    <uid>29</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="30" type="array">
-                    <uid>30</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="31" type="array">
-                    <uid>31</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="32" type="array">
-                    <uid>32</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="33" type="array">
-                    <uid>33</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="34" type="array">
-                    <uid>34</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="35" type="array">
-                    <uid>35</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="36" type="array">
-                    <uid>36</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="37" type="array">
-                    <uid>37</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="38" type="array">
-                    <uid>38</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="39" type="array">
-                    <uid>39</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="40" type="array">
-                    <uid>40</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="42" type="array">
-                    <uid>42</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="43" type="array">
-                    <uid>43</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="44" type="array">
-                    <uid>44</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="45" type="array">
-                    <uid>45</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="46" type="array">
-                    <uid>46</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="47" type="array">
-                    <uid>47</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                    <softrefs type="array"></softrefs>
-                </rec>
-                <rec index="48" type="array">
-                    <uid>48</uid>
-                    <pid>3</pid>
-                    <title>MODS</title>
-                    <relations index="rels" type="array">
-                        <element index="tx_dlf_formats:2" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
                         </element>
                     </relations>
                     <softrefs type="array"></softrefs>
@@ -1472,6 +611,44 @@
                 <rec index="49" type="array">
                     <uid>49</uid>
                     <pid>3</pid>
+                    <title>gefördert durch</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:82" type="array">
+                            <id>82</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="48" type="array">
+                    <uid>48</uid>
+                    <pid>3</pid>
+                    <title>digitale Bearbeitung Ton</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:60" type="array">
+                            <id>60</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="47" type="array">
+                    <uid>47</uid>
+                    <pid>3</pid>
+                    <title>verwendete Entzerrungskurve</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_metadataformat:59" type="array">
+                            <id>59</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+            </table>
+            <table index="tx_dlf_metadataformat" type="array">
+                <rec index="52" type="array">
+                    <uid>52</uid>
+                    <pid>3</pid>
                     <title>MODS</title>
                     <relations index="rels" type="array">
                         <element index="tx_dlf_formats:2" type="array">
@@ -1481,8 +658,8 @@
                     </relations>
                     <softrefs type="array"></softrefs>
                 </rec>
-                <rec index="50" type="array">
-                    <uid>50</uid>
+                <rec index="53" type="array">
+                    <uid>53</uid>
                     <pid>3</pid>
                     <title>MODS</title>
                     <relations index="rels" type="array">
@@ -1496,6 +673,50 @@
                 <rec index="54" type="array">
                     <uid>54</uid>
                     <pid>3</pid>
+                    <title>AUDIOMD</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:7" type="array">
+                            <id>7</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:51" type="array">
+                            <id>51</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:46" type="array">
+                            <id>46</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:42" type="array">
+                            <id>42</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:38" type="array">
+                            <id>38</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:35" type="array">
+                            <id>35</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:32" type="array">
+                            <id>32</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:29" type="array">
+                            <id>29</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:26" type="array">
+                            <id>26</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="55" type="array">
+                    <uid>55</uid>
+                    <pid>3</pid>
                     <title>MODS</title>
                     <relations index="rels" type="array">
                         <element index="tx_dlf_formats:2" type="array">
@@ -1503,6 +724,902 @@
                             <table>tx_dlf_formats</table>
                         </element>
                     </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="56" type="array">
+                    <uid>56</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="57" type="array">
+                    <uid>57</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="58" type="array">
+                    <uid>58</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="59" type="array">
+                    <uid>59</uid>
+                    <pid>3</pid>
+                    <title>AUDIOMD</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:7" type="array">
+                            <id>7</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="60" type="array">
+                    <uid>60</uid>
+                    <pid>3</pid>
+                    <title>AUDIOMD</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:7" type="array">
+                            <id>7</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="61" type="array">
+                    <uid>61</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="62" type="array">
+                    <uid>62</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="63" type="array">
+                    <uid>63</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="64" type="array">
+                    <uid>64</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="65" type="array">
+                    <uid>65</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="66" type="array">
+                    <uid>66</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="67" type="array">
+                    <uid>67</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="68" type="array">
+                    <uid>68</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="69" type="array">
+                    <uid>69</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="70" type="array">
+                    <uid>70</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:52" type="array">
+                            <id>52</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:47" type="array">
+                            <id>47</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="71" type="array">
+                    <uid>71</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="72" type="array">
+                    <uid>72</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="73" type="array">
+                    <uid>73</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="74" type="array">
+                    <uid>74</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="75" type="array">
+                    <uid>75</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="76" type="array">
+                    <uid>76</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="77" type="array">
+                    <uid>77</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:54" type="array">
+                            <id>54</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:49" type="array">
+                            <id>49</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:44" type="array">
+                            <id>44</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:39" type="array">
+                            <id>39</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="78" type="array">
+                    <uid>78</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="79" type="array">
+                    <uid>79</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="80" type="array">
+                    <uid>80</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="81" type="array">
+                    <uid>81</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="82" type="array">
+                    <uid>82</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="83" type="array">
+                    <uid>83</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:53" type="array">
+                            <id>53</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:48" type="array">
+                            <id>48</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:43" type="array">
+                            <id>43</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:40" type="array">
+                            <id>40</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:36" type="array">
+                            <id>36</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:33" type="array">
+                            <id>33</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:30" type="array">
+                            <id>30</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:27" type="array">
+                            <id>27</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:24" type="array">
+                            <id>24</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:22" type="array">
+                            <id>22</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:20" type="array">
+                            <id>20</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:18" type="array">
+                            <id>18</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:16" type="array">
+                            <id>16</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:14" type="array">
+                            <id>14</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:12" type="array">
+                            <id>12</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:10" type="array">
+                            <id>10</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:8" type="array">
+                            <id>8</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:6" type="array">
+                            <id>6</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:4" type="array">
+                            <id>4</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="tx_dlf_metadatasubentries:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="84" type="array">
+                    <uid>84</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="85" type="array">
+                    <uid>85</uid>
+                    <pid>3</pid>
+                    <title>TEIHDR</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:1" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="86" type="array">
+                    <uid>86</uid>
+                    <pid>3</pid>
+                    <title>TEIHDR</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:1" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="87" type="array">
+                    <uid>87</uid>
+                    <pid>3</pid>
+                    <title>TEIHDR</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:1" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="88" type="array">
+                    <uid>88</uid>
+                    <pid>3</pid>
+                    <title>TEIHDR</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:1" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="89" type="array">
+                    <uid>89</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="90" type="array">
+                    <uid>90</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="91" type="array">
+                    <uid>91</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="92" type="array">
+                    <uid>92</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="93" type="array">
+                    <uid>93</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="94" type="array">
+                    <uid>94</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="95" type="array">
+                    <uid>95</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="96" type="array">
+                    <uid>96</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="97" type="array">
+                    <uid>97</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="98" type="array">
+                    <uid>98</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="99" type="array">
+                    <uid>99</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="100" type="array">
+                    <uid>100</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="101" type="array">
+                    <uid>101</uid>
+                    <pid>3</pid>
+                    <title>MODS</title>
+                    <relations index="rels" type="array">
+                        <element index="tx_dlf_formats:2" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+            </table>
+            <table index="tx_dlf_metadatasubentries" type="array">
+                <rec index="51" type="array">
+                    <uid>51</uid>
+                    <pid>3</pid>
+                    <title>Trägertyp</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="52" type="array">
+                    <uid>52</uid>
+                    <pid>3</pid>
+                    <title>Name</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="53" type="array">
+                    <uid>53</uid>
+                    <pid>3</pid>
+                    <title>Vorlagetitel</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="54" type="array">
+                    <uid>54</uid>
+                    <pid>3</pid>
+                    <title>digitalisiert in</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="46" type="array">
+                    <uid>46</uid>
+                    <pid>3</pid>
+                    <title>Trägerformat</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="47" type="array">
+                    <uid>47</uid>
+                    <pid>3</pid>
+                    <title>Rolle</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="48" type="array">
+                    <uid>48</uid>
+                    <pid>3</pid>
+                    <title>Ausgabe</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="49" type="array">
+                    <uid>49</uid>
+                    <pid>3</pid>
+                    <title>digitalisiert am</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="42" type="array">
+                    <uid>42</uid>
+                    <pid>3</pid>
+                    <title>Produktionsstufe</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="43" type="array">
+                    <uid>43</uid>
+                    <pid>3</pid>
+                    <title>Besetzung</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="44" type="array">
+                    <uid>44</uid>
+                    <pid>3</pid>
+                    <title>digitalisiert durch</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="38" type="array">
+                    <uid>38</uid>
+                    <pid>3</pid>
+                    <title>Abspielgeschwindigkeit</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="39" type="array">
+                    <uid>39</uid>
+                    <pid>3</pid>
+                    <title>Digitalisat veröffentlicht</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="40" type="array">
+                    <uid>40</uid>
+                    <pid>3</pid>
+                    <title>Einrichtung</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="35" type="array">
+                    <uid>35</uid>
+                    <pid>3</pid>
+                    <title>Laufzeit</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="36" type="array">
+                    <uid>36</uid>
+                    <pid>3</pid>
+                    <title>Signatur</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="32" type="array">
+                    <uid>32</uid>
+                    <pid>3</pid>
+                    <title>Klangfeld</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="33" type="array">
+                    <uid>33</uid>
+                    <pid>3</pid>
+                    <title>Ehem. Signatur</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="29" type="array">
+                    <uid>29</uid>
+                    <pid>3</pid>
+                    <title>Informationen zu Audiospuren</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="30" type="array">
+                    <uid>30</uid>
+                    <pid>3</pid>
+                    <title>Erscheinungsort</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="26" type="array">
+                    <uid>26</uid>
+                    <pid>3</pid>
+                    <title>Zustandshinweis</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="27" type="array">
+                    <uid>27</uid>
+                    <pid>3</pid>
+                    <title>Entstehungsort</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="24" type="array">
+                    <uid>24</uid>
+                    <pid>3</pid>
+                    <title>Erscheinungsjahr</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="22" type="array">
+                    <uid>22</uid>
+                    <pid>3</pid>
+                    <title>Entstehungszeit</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="20" type="array">
+                    <uid>20</uid>
+                    <pid>3</pid>
+                    <title>Entstehungszeit (Verlauf)</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="18" type="array">
+                    <uid>18</uid>
+                    <pid>3</pid>
+                    <title>Erscheinungszeit (Verlauf)</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="16" type="array">
+                    <uid>16</uid>
+                    <pid>3</pid>
+                    <title>Umfang</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="14" type="array">
+                    <uid>14</uid>
+                    <pid>3</pid>
+                    <title>Format</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="12" type="array">
+                    <uid>12</uid>
+                    <pid>3</pid>
+                    <title>Sprache</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="10" type="array">
+                    <uid>10</uid>
+                    <pid>3</pid>
+                    <title>Notation</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="8" type="array">
+                    <uid>8</uid>
+                    <pid>3</pid>
+                    <title>Plattennummer</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="6" type="array">
+                    <uid>6</uid>
+                    <pid>3</pid>
+                    <title>Verlag</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="4" type="array">
+                    <uid>4</uid>
+                    <pid>3</pid>
+                    <title>Ausgabe</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="2" type="array">
+                    <uid>2</uid>
+                    <pid>3</pid>
+                    <title>Anmerkung</title>
+                    <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
             </table>
@@ -3604,10 +3721,11 @@
                     <item index="1">1</item>
                 </table>
                 <table index="tx_dlf_formats" type="array">
-                    <item index="3">1</item>
-                    <item index="4">1</item>
-                    <item index="5">1</item>
                     <item index="6">1</item>
+                    <item index="7">1</item>
+                    <item index="5">1</item>
+                    <item index="4">1</item>
+                    <item index="3">1</item>
                     <item index="2">1</item>
                     <item index="1">1</item>
                 </table>
@@ -3626,104 +3744,134 @@
             </page_contents>
             <page_contents index="3" type="array">
                 <table index="tx_dlf_metadata" type="array">
-                    <item index="31">1</item>
-                    <item index="35">1</item>
-                    <item index="32">1</item>
-                    <item index="36">1</item>
-                    <item index="46">1</item>
-                    <item index="45">1</item>
-                    <item index="44">1</item>
-                    <item index="43">1</item>
-                    <item index="42">1</item>
-                    <item index="38">1</item>
-                    <item index="41">1</item>
-                    <item index="37">1</item>
-                    <item index="34">1</item>
-                    <item index="33">1</item>
-                    <item index="30">1</item>
-                    <item index="29">1</item>
-                    <item index="28">1</item>
-                    <item index="27">1</item>
-                    <item index="26">1</item>
-                    <item index="25">1</item>
-                    <item index="23">1</item>
-                    <item index="21">1</item>
-                    <item index="19">1</item>
-                    <item index="17">1</item>
-                    <item index="15">1</item>
-                    <item index="13">1</item>
-                    <item index="11">1</item>
-                    <item index="9">1</item>
-                    <item index="3">1</item>
-                    <item index="40">1</item>
-                    <item index="7">1</item>
-                    <item index="6">1</item>
-                    <item index="5">1</item>
-                    <item index="4">1</item>
-                    <item index="1">1</item>
-                    <item index="24">1</item>
-                    <item index="22">1</item>
-                    <item index="20">1</item>
-                    <item index="18">1</item>
-                    <item index="16">1</item>
-                    <item index="14">1</item>
-                    <item index="12">1</item>
-                    <item index="10">1</item>
-                    <item index="8">1</item>
-                    <item index="2">1</item>
-                    <item index="39">1</item>
+                    <item index="87">1</item>
+                    <item index="86">1</item>
+                    <item index="85">1</item>
+                    <item index="84">1</item>
+                    <item index="83">1</item>
+                    <item index="82">1</item>
+                    <item index="81">1</item>
+                    <item index="80">1</item>
+                    <item index="79">1</item>
+                    <item index="78">1</item>
+                    <item index="77">1</item>
+                    <item index="76">1</item>
+                    <item index="75">1</item>
+                    <item index="74">1</item>
+                    <item index="73">1</item>
+                    <item index="72">1</item>
+                    <item index="71">1</item>
+                    <item index="70">1</item>
+                    <item index="69">1</item>
+                    <item index="68">1</item>
+                    <item index="67">1</item>
+                    <item index="66">1</item>
+                    <item index="65">1</item>
+                    <item index="64">1</item>
+                    <item index="63">1</item>
+                    <item index="62">1</item>
+                    <item index="61">1</item>
+                    <item index="60">1</item>
+                    <item index="58">1</item>
+                    <item index="57">1</item>
+                    <item index="56">1</item>
+                    <item index="55">1</item>
+                    <item index="54">1</item>
+                    <item index="53">1</item>
+                    <item index="52">1</item>
+                    <item index="51">1</item>
+                    <item index="50">1</item>
+                    <item index="49">1</item>
+                    <item index="48">1</item>
+                    <item index="47">1</item>
                 </table>
                 <table index="tx_dlf_metadataformat" type="array">
-                    <item index="1">1</item>
-                    <item index="2">1</item>
-                    <item index="3">1</item>
-                    <item index="4">1</item>
-                    <item index="5">1</item>
-                    <item index="6">1</item>
-                    <item index="7">1</item>
-                    <item index="8">1</item>
-                    <item index="9">1</item>
-                    <item index="10">1</item>
-                    <item index="11">1</item>
-                    <item index="12">1</item>
-                    <item index="13">1</item>
-                    <item index="14">1</item>
-                    <item index="15">1</item>
-                    <item index="16">1</item>
-                    <item index="17">1</item>
-                    <item index="18">1</item>
-                    <item index="19">1</item>
-                    <item index="20">1</item>
-                    <item index="21">1</item>
-                    <item index="22">1</item>
-                    <item index="23">1</item>
-                    <item index="24">1</item>
-                    <item index="25">1</item>
-                    <item index="26">1</item>
-                    <item index="27">1</item>
-                    <item index="28">1</item>
-                    <item index="29">1</item>
-                    <item index="30">1</item>
-                    <item index="31">1</item>
-                    <item index="32">1</item>
-                    <item index="33">1</item>
-                    <item index="34">1</item>
-                    <item index="35">1</item>
-                    <item index="36">1</item>
-                    <item index="37">1</item>
-                    <item index="38">1</item>
-                    <item index="39">1</item>
-                    <item index="40">1</item>
-                    <item index="42">1</item>
-                    <item index="43">1</item>
-                    <item index="44">1</item>
-                    <item index="45">1</item>
+                    <item index="52">1</item>
+                    <item index="53">1</item>
+                    <item index="54">1</item>
+                    <item index="55">1</item>
+                    <item index="56">1</item>
+                    <item index="57">1</item>
+                    <item index="58">1</item>
+                    <item index="59">1</item>
+                    <item index="60">1</item>
+                    <item index="61">1</item>
+                    <item index="62">1</item>
+                    <item index="63">1</item>
+                    <item index="64">1</item>
+                    <item index="65">1</item>
+                    <item index="66">1</item>
+                    <item index="67">1</item>
+                    <item index="68">1</item>
+                    <item index="69">1</item>
+                    <item index="70">1</item>
+                    <item index="71">1</item>
+                    <item index="72">1</item>
+                    <item index="73">1</item>
+                    <item index="74">1</item>
+                    <item index="75">1</item>
+                    <item index="76">1</item>
+                    <item index="77">1</item>
+                    <item index="78">1</item>
+                    <item index="79">1</item>
+                    <item index="80">1</item>
+                    <item index="81">1</item>
+                    <item index="82">1</item>
+                    <item index="83">1</item>
+                    <item index="84">1</item>
+                    <item index="85">1</item>
+                    <item index="86">1</item>
+                    <item index="87">1</item>
+                    <item index="88">1</item>
+                    <item index="89">1</item>
+                    <item index="90">1</item>
+                    <item index="91">1</item>
+                    <item index="92">1</item>
+                    <item index="93">1</item>
+                    <item index="94">1</item>
+                    <item index="95">1</item>
+                    <item index="96">1</item>
+                    <item index="97">1</item>
+                    <item index="98">1</item>
+                    <item index="99">1</item>
+                    <item index="100">1</item>
+                    <item index="101">1</item>
+                </table>
+                <table index="tx_dlf_metadatasubentries" type="array">
+                    <item index="51">1</item>
+                    <item index="52">1</item>
+                    <item index="53">1</item>
+                    <item index="54">1</item>
                     <item index="46">1</item>
                     <item index="47">1</item>
                     <item index="48">1</item>
                     <item index="49">1</item>
-                    <item index="50">1</item>
-                    <item index="54">1</item>
+                    <item index="42">1</item>
+                    <item index="43">1</item>
+                    <item index="44">1</item>
+                    <item index="38">1</item>
+                    <item index="39">1</item>
+                    <item index="40">1</item>
+                    <item index="35">1</item>
+                    <item index="36">1</item>
+                    <item index="32">1</item>
+                    <item index="33">1</item>
+                    <item index="29">1</item>
+                    <item index="30">1</item>
+                    <item index="26">1</item>
+                    <item index="27">1</item>
+                    <item index="24">1</item>
+                    <item index="22">1</item>
+                    <item index="20">1</item>
+                    <item index="18">1</item>
+                    <item index="16">1</item>
+                    <item index="14">1</item>
+                    <item index="12">1</item>
+                    <item index="10">1</item>
+                    <item index="8">1</item>
+                    <item index="6">1</item>
+                    <item index="4">1</item>
+                    <item index="2">1</item>
                 </table>
                 <table index="tx_dlf_structures" type="array">
                     <item index="177">1</item>
@@ -3974,12 +4122,12 @@
             </fieldlist>
             <related index="rels" type="array"></related>
         </tablerow>
-        <tablerow index="tx_dlf_formats:3" type="array">
+        <tablerow index="tx_dlf_formats:6" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">3</field>
-                <field index="pid" type="integer">0</field>
-                <field index="tstamp" type="integer">1620333535</field>
-                <field index="crdate" type="integer">1620333535</field>
+                <field index="uid" type="integer">6</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
                 <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="type">ALTO</field>
@@ -3989,12 +4137,27 @@
             </fieldlist>
             <related index="rels" type="array"></related>
         </tablerow>
-        <tablerow index="tx_dlf_formats:4" type="array">
+        <tablerow index="tx_dlf_formats:7" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">4</field>
-                <field index="pid" type="integer">0</field>
-                <field index="tstamp" type="integer">1620333535</field>
-                <field index="crdate" type="integer">1620333535</field>
+                <field index="uid" type="integer">7</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="type">AUDIOMD</field>
+                <field index="root">audiomd</field>
+                <field index="namespace">https://www.loc.gov/standards/amdvmd/</field>
+                <field index="class">Kitodo\Dlf\Format\audiomd</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_formats:5" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">5</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
                 <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="type">IIIF1</field>
@@ -4004,12 +4167,12 @@
             </fieldlist>
             <related index="rels" type="array"></related>
         </tablerow>
-        <tablerow index="tx_dlf_formats:5" type="array">
+        <tablerow index="tx_dlf_formats:4" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">5</field>
-                <field index="pid" type="integer">0</field>
-                <field index="tstamp" type="integer">1620333535</field>
-                <field index="crdate" type="integer">1620333535</field>
+                <field index="uid" type="integer">4</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
                 <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="type">IIIF2</field>
@@ -4019,12 +4182,12 @@
             </fieldlist>
             <related index="rels" type="array"></related>
         </tablerow>
-        <tablerow index="tx_dlf_formats:6" type="array">
+        <tablerow index="tx_dlf_formats:3" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">6</field>
-                <field index="pid" type="integer">0</field>
-                <field index="tstamp" type="integer">1620333535</field>
-                <field index="crdate" type="integer">1620333535</field>
+                <field index="uid" type="integer">3</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
                 <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="type">IIIF3</field>
@@ -4037,10 +4200,10 @@
         <tablerow index="tx_dlf_formats:2" type="array">
             <fieldlist index="data" type="array">
                 <field index="uid" type="integer">2</field>
-                <field index="pid" type="integer">0</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="type">MODS</field>
                 <field index="root">mods</field>
@@ -4052,10 +4215,10 @@
         <tablerow index="tx_dlf_formats:1" type="array">
             <fieldlist index="data" type="array">
                 <field index="uid" type="integer">1</field>
-                <field index="pid" type="integer">0</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="type">TEIHDR</field>
                 <field index="root">teiHeader</field>
@@ -4400,160 +4563,73 @@
             </fieldlist>
             <related index="rels" type="array"></related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:31" type="array">
+        <tablerow index="tx_dlf_metadata:87" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">31</field>
+                <field index="uid" type="integer">87</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620385819</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">32</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">2</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Title</field>
-                <field index="index_name">title0</field>
-                <field index="format" type="integer">2</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt class=&quot;tx-dlf-title&quot;&gt;|&lt;/dt&gt;
-                    value.ifEmpty.field = parentTitle
-                    value.ifEmpty.wrap = [|]
-                    value.required = 1
-                    value.wrap = &lt;dd class=&quot;tx-dlf-title&quot;&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>32</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>19</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="1" type="array">
-                            <id>45</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:35" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">35</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620385832</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">36</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Author</field>
-                <field index="index_name">author0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;&lt;dd&gt;
-                    value.ifEmpty.field = parentAuthor
-                    value.required = 1
-                    value.noTrimWrap = ||; |
-                    all.substring = 0,-2
-                    all.wrap = |&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>36</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>11</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:32" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">32</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620385819</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">4</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">256</field>
+                <field index="label">Einheitssachtitel</field>
+                <field index="index_name">uniform_title</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;
+                </field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>79</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:86" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">86</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">512</field>
                 <field index="label">Titel</field>
                 <field index="index_name">title</field>
                 <field index="format" type="integer">2</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt class=&quot;tx-dlf-title&quot;&gt;|&lt;/dt&gt;
-                    value.ifEmpty.field = parentTitle
-                    value.ifEmpty.wrap = [|]
-                    value.required = 1
-                    value.wrap = &lt;dd class=&quot;tx-dlf-title&quot;&gt;|&lt;/dd&gt;</field>
+value.ifEmpty.field = parentTitle
+value.ifEmpty.wrap = [|]
+value.required = 1
+value.wrap = &lt;dd class=&quot;tx-dlf-title&quot;&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4569,41 +4645,169 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>1</id>
+                            <id>85</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                         <element index="1" type="array">
-                            <id>23</id>
+                            <id>91</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:36" type="array">
+        <tablerow index="tx_dlf_metadata:85" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">36</field>
+                <field index="uid" type="integer">85</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620385832</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">6</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Autor</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">513</field>
+                <field index="label">Titelübersetzung</field>
+                <field index="index_name">title_translated</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;
+                </field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>66</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:84" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">84</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">514</field>
+                <field index="label">Serientitel</field>
+                <field index="index_name">title_series</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>58</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:83" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">83</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">516</field>
+                <field index="label">Fassung</field>
+                <field index="index_name">other_version</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>53</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:82" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">82</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">520</field>
+                <field index="label">Autor:in</field>
                 <field index="index_name">author</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;&lt;dd&gt;
-                    value.ifEmpty.field = parentAuthor
-                    value.required = 1
-                    value.noTrimWrap = ||; |
-                    all.substring = 0,-2
-                    all.wrap = |&lt;/dd&gt;</field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.ifEmpty.field = parentAuthor
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4619,34 +4823,34 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>2</id>
+                            <id>86</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:46" type="array">
+        <tablerow index="tx_dlf_metadata:81" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">46</field>
+                <field index="uid" type="integer">81</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
                 <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">8</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Aufbewahrungsort</field>
-                <field index="index_name">settlement</field>
+                <field index="sorting" type="integer">528</field>
+                <field index="label">Regisseur:in</field>
+                <field index="index_name">film_director</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4662,34 +4866,34 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>10</id>
+                            <id>69</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:45" type="array">
+        <tablerow index="tx_dlf_metadata:80" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">45</field>
+                <field index="uid" type="integer">80</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">46</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
                 <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">16</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Settlement</field>
-                <field index="index_name">settlement0</field>
+                <field index="sorting" type="integer">544</field>
+                <field index="label">Filmemacher:in</field>
+                <field index="index_name">filmmaker</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4701,64 +4905,38 @@
                 <field index="status" type="integer">0</field>
             </fieldlist>
             <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>46</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
                 <field index="format" type="array">
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>12</id>
+                            <id>68</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:44" type="array">
+        <tablerow index="tx_dlf_metadata:79" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">44</field>
+                <field index="uid" type="integer">79</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">32</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Zeitraum</field>
-                <field index="index_name">creationDateRun</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">576</field>
+                <field index="label">Komponist:in</field>
+                <field index="index_name">composer</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.replacement.1.search = /(\s)/
-                    value.replacement.1.replace = $1-$1
-                    value.replacement.1.useRegExp = 1
-                    value.replacement.2.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
-                    value.replacement.2.replace = $3.$2.$1
-                    value.replacement.2.useRegExp = 1
-                    value.required = 1
-                    value.noTrimWrap = ||, |
-                    all.substring = 0,-2
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4774,106 +4952,34 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>27</id>
+                            <id>78</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:43" type="array">
+        <tablerow index="tx_dlf_metadata:78" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">43</field>
+                <field index="uid" type="integer">78</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">44</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">64</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Period</field>
-                <field index="index_name">creationDateRun0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.replacement.1.search = /(\s)/
-                    value.replacement.1.replace = $1-$1
-                    value.replacement.1.useRegExp = 1
-                    value.replacement.2.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
-                    value.replacement.2.replace = $3.$2.$1
-                    value.replacement.2.useRegExp = 1
-                    value.required = 1
-                    value.noTrimWrap = ||, |
-                    all.substring = 0,-2
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>44</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>48</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:42" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">42</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">128</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Erstellungsdatum</field>
-                <field index="index_name">creationDate</field>
-                <field index="format" type="integer">2</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">640</field>
+                <field index="label">Librettist:in</field>
+                <field index="index_name">libretist</field>
+                <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.replacement.1.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
-                    value.replacement.1.replace = $3.$2.$1
-                    value.replacement.1.useRegExp = 1
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4889,38 +4995,120 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>3</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="1" type="array">
-                            <id>26</id>
+                            <id>76</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:38" type="array">
+        <tablerow index="tx_dlf_metadata:77" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">38</field>
+                <field index="uid" type="integer">77</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386143</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;hidden&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">192</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Erscheinungsjahr (Gesamtheit)</field>
-                <field index="index_name">parentYear</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">768</field>
+                <field index="label">Widmungsadressat:in</field>
+                <field index="index_name">dedicatee</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>75</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:76" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">76</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1024</field>
+                <field index="label">Schreiber:in</field>
+                <field index="index_name">scriptor</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>81</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:75" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">75</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1025</field>
+                <field index="label">Bearbeiter:in</field>
+                <field index="index_name">arranger</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">0</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4936,37 +5124,35 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>25</id>
+                            <id>71</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:41" type="array">
+        <tablerow index="tx_dlf_metadata:74" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">41</field>
+                <field index="uid" type="integer">74</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">42</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">256</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Creation Date</field>
-                <field index="index_name">creationDate0</field>
-                <field index="format" type="integer">2</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1026</field>
+                <field index="label">Interpret:in</field>
+                <field index="index_name">performer</field>
+                <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.replacement.1.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
-                    value.replacement.1.replace = $3.$2.$1
-                    value.replacement.1.useRegExp = 1
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;&lt;dl class=&quot;tx-dlf-metadata-subentry&quot;&gt;|&lt;/dl&gt;&lt;/dd&gt;
+                </field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -4978,62 +5164,82 @@
                 <field index="status" type="integer">0</field>
             </fieldlist>
             <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>42</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
                 <field index="format" type="array">
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>20</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="1" type="array">
-                            <id>46</id>
+                            <id>70</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:37" type="array">
+        <tablerow index="tx_dlf_metadata:73" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">37</field>
+                <field index="uid" type="integer">73</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386143</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">38</field>
-                <field index="l18n_diffsource">a:15:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;i:1;s:4:&quot;wrap&quot;;s:64:&quot;key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;&quot;;s:10:&quot;index_name&quot;;s:10:&quot;parentYear&quot;;s:15:&quot;index_tokenized&quot;;i:0;s:12:&quot;index_stored&quot;;i:0;s:13:&quot;index_indexed&quot;;i:1;s:11:&quot;index_boost&quot;;d:1;s:11:&quot;is_sortable&quot;;i:0;s:8:&quot;is_facet&quot;;i:0;s:9:&quot;is_listed&quot;;i:0;s:18:&quot;index_autocomplete&quot;;i:0;s:6:&quot;status&quot;;i:0;s:6:&quot;hidden&quot;;i:1;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">912</field>
-                <field index="l10n_state">{&quot;wrap&quot;:&quot;parent&quot;}</field>
-                <field index="label">Year of Publication (Parent)</field>
-                <field index="index_name">parentYear0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1028</field>
+                <field index="label">Dirigent:in</field>
+                <field index="index_name">conductor</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>67</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:72" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">72</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1032</field>
+                <field index="label">Interviewpartner:in</field>
+                <field index="index_name">interviewee</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;
+                </field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">0</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -5045,24 +5251,580 @@
                 <field index="status" type="integer">0</field>
             </fieldlist>
             <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
+                <field index="format" type="array">
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
+                            <id>65</id>
+                            <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
-                <field index="l18n_parent" type="array">
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:71" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">71</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1040</field>
+                <field index="label">Inhalt</field>
+                <field index="index_name">abstract</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;
+                </field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>38</id>
-                            <table>tx_dlf_metadata</table>
+                            <id>57</id>
+                            <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:70" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">70</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1056</field>
+                <field index="label">Schlagwörter</field>
+                <field index="index_name">keywords</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>56</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:69" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">69</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1088</field>
+                <field index="label">Ortsbezug</field>
+                <field index="index_name">geographic_reference</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">0</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">0</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>55</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:68" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">68</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1152</field>
+                <field index="label">Genre</field>
+                <field index="index_name">genre</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>80</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:67" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">67</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1280</field>
+                <field index="label">PURL</field>
+                <field index="index_name">purl</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>73</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:66" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">66</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1536</field>
+                <field index="label">SLUB-Katalog (PPN)</field>
+                <field index="index_name">kxp_ppn</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>64</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:65" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">65</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1537</field>
+                <field index="label">SWB (PPN)</field>
+                <field index="index_name">swb_ppn</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>63</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:64" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">64</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1538</field>
+                <field index="label">Rechte-/Lizenzhinweis</field>
+                <field index="index_name">rightsstatement</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">0</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">0</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>72</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:63" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">63</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1540</field>
+                <field index="label">Nutzungshinweis</field>
+                <field index="index_name">terms_of_use</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>62</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:62" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">62</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1544</field>
+                <field index="label">Nutzungseinschränkung</field>
+                <field index="index_name">use_restrictions</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">0</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">0</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>52</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:61" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">61</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1552</field>
+                <field index="label">Rechteinhaber:in</field>
+                <field index="index_name">rightsholder</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">0</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">0</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>61</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:60" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">60</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;index_tokenized&quot;:&quot;&quot;,&quot;index_stored&quot;:&quot;&quot;,&quot;index_indexed&quot;:&quot;&quot;,&quot;index_boost&quot;:&quot;&quot;,&quot;is_sortable&quot;:&quot;&quot;,&quot;is_facet&quot;:&quot;&quot;,&quot;is_listed&quot;:&quot;&quot;,&quot;index_autocomplete&quot;:&quot;&quot;,&quot;format&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;,&quot;hidden&quot;:&quot;&quot;,&quot;status&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1568</field>
+                <field index="label">Angaben zum Original</field>
+                <field index="index_name">info_original</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;&lt;dl class=&quot;tx-dlf-metadata-subentry&quot;&gt;|&lt;/dl&gt;&lt;/dd&gt;
+                </field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>83</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:58" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">58</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1664</field>
+                <field index="label">Technische Metadaten</field>
+                <field index="index_name">technical_metadata</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;&lt;dl class=&quot;tx-dlf-metadata-subentry&quot;&gt;|&lt;/dl&gt;&lt;/dd&gt;
+                </field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
                 <field index="format" type="array">
                     <type>db</type>
                     <relations index="itemArray" type="array">
@@ -5074,237 +5836,30 @@
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:34" type="array">
+        <tablerow index="tx_dlf_metadata:57" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">34</field>
+                <field index="uid" type="integer">57</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">1568</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Autor (Gesamtheit)</field>
-                <field index="index_name">parentAuthor</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>24</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:33" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">33</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">34</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">1600</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Author (Parent)</field>
-                <field index="index_name">parentAuthor0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>34</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>38</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:30" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">30</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">2048</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Gesamttitel</field>
-                <field index="index_name">parentTitle</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>22</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:29" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">29</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">30</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">2561</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Parent Title</field>
-                <field index="index_name">parentTitle0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>30</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>43</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:28" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">28</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
                 <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3074</field>
-                <field index="l10n_state" type="NULL"></field>
+                <field index="sorting" type="integer">1792</field>
                 <field index="label">Kontext</field>
                 <field index="index_name">context</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;&lt;dd&gt;
-                    value.required = 1
-                    value.noTrimWrap = || &amp;gt; |
+value.required = 1
+value.noTrimWrap = || &amp;gt; |
                     all.substring = 0,-6
-                    all.wrap = |&lt;/dd&gt;</field>
+                    all.wrap = |&lt;/dd&gt;
+                </field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -5320,138 +5875,48 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>21</id>
+                            <id>89</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:27" type="array">
+        <tablerow index="tx_dlf_metadata:56" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">27</field>
+                <field index="uid" type="integer">56</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">28</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3076</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Context</field>
-                <field index="index_name">context0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;&lt;dd&gt;
-                    value.required = 1
-                    value.noTrimWrap = || &amp;gt; |
-                    all.substring = 0,-6
-                    all.wrap = |&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>28</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>47</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:26" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">26</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:16:{s:5:&quot;label&quot;;N;s:10:&quot;index_name&quot;;N;s:15:&quot;index_tokenized&quot;;N;s:12:&quot;index_stored&quot;;N;s:13:&quot;index_indexed&quot;;N;s:11:&quot;index_boost&quot;;N;s:11:&quot;is_sortable&quot;;N;s:8:&quot;is_facet&quot;;N;s:9:&quot;is_listed&quot;;N;s:18:&quot;index_autocomplete&quot;;N;s:6:&quot;format&quot;;N;s:13:&quot;default_value&quot;;N;s:4:&quot;wrap&quot;;N;s:16:&quot;sys_language_uid&quot;;N;s:6:&quot;hidden&quot;;N;s:6:&quot;status&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">3080</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Strukturtyp</field>
-                <field index="index_name">type</field>
-                <field index="format" type="integer">0</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt class=&quot;tx-dlf-type&quot;&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd class=&quot;tx-dlf-type&quot;&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array"></related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:25" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">25</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386192</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
                 <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3095</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Erscheinungsverlauf</field>
-                <field index="index_name">publicationRun</field>
+                <field index="sorting" type="integer">2048</field>
+                <field index="label">RISM</field>
+                <field index="index_name">rism_identifier</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.replacement.1.search = /(\s)/
-                    value.replacement.1.replace = $1-$1
-                    value.replacement.1.useRegExp = 1
-                    value.replacement.2.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
-                    value.replacement.2.replace = $3.$2.$1
-                    value.replacement.2.useRegExp = 1
-                    value.required = 1
-                    value.noTrimWrap = ||, |
-                    all.substring = 0,-2
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter {
+                    current = 1
+                    split {
+                    token = -
+                    returnKey = 2
+                    }
+                    rawUrlEncode = 1
+                    prepend = TEXT
+                    prepend.value = https://opac.rism.info/search?id=
+                    append = TEXT
+                    append.value = &amp;View=rism
+                    }
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;
+                </field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -5467,77 +5932,34 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>28</id>
+                            <id>84</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:23" type="array">
+        <tablerow index="tx_dlf_metadata:55" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">23</field>
+                <field index="uid" type="integer">55</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386673</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">3102</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Erscheinungsort (Gesamtheit)</field>
-                <field index="index_name">parentPlace</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2049</field>
+                <field index="label">Werkverzeichnisnummer</field>
+                <field index="index_name">cataloguenumber</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>29</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:21" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">21</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386757</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3106</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Einrichtung</field>
-                <field index="index_name">repository</field>
-                <field index="format" type="integer">2</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -5553,87 +5975,36 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>9</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="1" type="array">
-                            <id>35</id>
+                            <id>74</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:19" type="array">
+        <tablerow index="tx_dlf_metadata:54" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">19</field>
+                <field index="uid" type="integer">54</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386766</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3108</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Signatur</field>
-                <field index="index_name">shelfmark</field>
-                <field index="format" type="integer">2</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>8</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="1" type="array">
-                            <id>34</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:17" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">17</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386781</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
                 <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3109</field>
-                <field index="l10n_state" type="NULL"></field>
+                <field index="sorting" type="integer">2050</field>
                 <field index="label">Band</field>
                 <field index="index_name">volume</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.if.value.field = type
-                    value.if.equals = volume
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.if.value.field = type
+value.if.equals = volume
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -5649,36 +6020,36 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>33</id>
+                            <id>101</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:15" type="array">
+        <tablerow index="tx_dlf_metadata:53" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">15</field>
+                <field index="uid" type="integer">53</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386823</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3365</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2052</field>
                 <field index="label">Ausgabe</field>
                 <field index="index_name">issue</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.if.value.field = type
-                    value.if.equals = issue
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+value.if.value.field = type
+value.if.equals = issue
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -5694,254 +6065,41 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>32</id>
+                            <id>100</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:13" type="array">
+        <tablerow index="tx_dlf_metadata:52" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">13</field>
+                <field index="uid" type="integer">52</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386847</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3493</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
-                <field index="label">Beschreibstoff</field>
-                <field index="index_name">material</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>7</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:11" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">11</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386860</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
                 <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3557</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Blattzahl</field>
-                <field index="index_name">leavesCount0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>6</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:9" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">9</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386874</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3589</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Format</field>
-                <field index="index_name">format</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.if.value.field = format
-                    value.if.equals = x
-                    value.if.negate = 1
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>5</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:3" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">3</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386957</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3605</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Erscheinungsort</field>
-                <field index="index_name">place</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.ifEmpty.field = parentPlace
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>4</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:40" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">40</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386039</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;hidden&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">3622</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Erscheinungsjahr</field>
-                <field index="index_name">year</field>
-                <field index="format" type="integer">0</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array"></related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:7" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">7</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">0</field>
-                <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">4612</field>
-                <field index="l10n_state" type="NULL"></field>
+                <field index="sorting" type="integer">2056</field>
                 <field index="label">VD16</field>
                 <field index="index_name">vd16</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.setContentToCurrent = 1
-                    value.required = 1
-                    value.typolink.parameter.current = 1
-                    value.typolink.parameter.replacement {
-                        10 {
-                            search = #\s#i
-                            replace = +
-                            useRegExp = 1
-                        }
-                    }
-                    value.typolink.parameter.prepend = TEXT
-                    value.typolink.parameter.prepend.value = https://gateway-bayern.de/VD16+
-                    value.wrap = &lt;dd&gt;[|]&lt;/dd&gt;</field>
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.typolink.parameter.rawUrlEncode = 1
+value.typolink.parameter.prepend = TEXT
+value.typolink.parameter.prepend.value =
+                    http://gateway-bayern.bib-bvb.de/aleph-cgi/bvb_suche?sid=VD16&amp;find_code_1=WVD&amp;find_request_1=
+value.wrap = &lt;dd&gt;[|]&lt;/dd&gt;
+                </field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -5957,105 +6115,40 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>31</id>
+                            <id>99</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:6" type="array">
+        <tablerow index="tx_dlf_metadata:51" type="array">
             <fieldlist index="data" type="array">
-                <field index="uid" type="integer">6</field>
+                <field index="uid" type="integer">51</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">7</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">4616</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">VD16</field>
-                <field index="index_name">vd160</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.setContentToCurrent = 1
-                    value.required = 1
-                    value.typolink.parameter.current = 1
-                    value.typolink.parameter.rawUrlEncode = 1
-                    value.typolink.parameter.prepend = TEXT
-                    value.typolink.parameter.prepend.value = http://gateway-bayern.bib-bvb.de/aleph-cgi/bvb_suche?sid=VD16&amp;find_code_1=WVD&amp;find_request_1=
-                    value.wrap = &lt;dd&gt;[|]&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>7</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>49</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:5" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">5</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
-                <field index="l18n_diffsource">a:1:{s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">4624</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
                 <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2064</field>
                 <field index="label">VD17</field>
                 <field index="index_name">vd17</field>
                 <field index="format" type="integer">1</field>
                 <field index="default_value"></field>
                 <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.setContentToCurrent = 1
-                    value.required = 1
-                    value.typolink.parameter.current = 1
-                    value.typolink.parameter.rawUrlEncode = 1
-                    value.typolink.parameter.prepend = TEXT
-                    value.typolink.parameter.prepend.value = https://kxp.k10plus.de/DB=1.28/CMD?ACT=SRCHA&amp;IKT=8079&amp;TRM=
-                    value.wrap = &lt;dd&gt;[|]&lt;/dd&gt;</field>
+value.setContentToCurrent = 1
+value.required = 1
+value.typolink.parameter.current = 1
+value.typolink.parameter.rawUrlEncode = 1
+value.typolink.parameter.prepend = TEXT
+value.typolink.parameter.prepend.value = http://gso.gbv.de/xslt/DB=1.28/SET=1/TTL=1/CMD?ACT=SRCHA&amp;IKT=8002&amp;TRM=
+value.wrap = &lt;dd&gt;[|]&lt;/dd&gt;
+                </field>
                 <field index="index_tokenized" type="integer">0</field>
                 <field index="index_stored" type="integer">1</field>
                 <field index="index_indexed" type="integer">1</field>
@@ -6071,2079 +6164,228 @@
                     <type>db</type>
                     <relations index="itemArray" type="array">
                         <element index="0" type="array">
-                            <id>30</id>
+                            <id>98</id>
                             <table>tx_dlf_metadataformat</table>
                         </element>
                     </relations>
                 </field>
             </related>
         </tablerow>
-        <tablerow index="tx_dlf_metadata:4" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">4</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">5</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">4640</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">VD17</field>
-                <field index="index_name">vd170</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.setContentToCurrent = 1
-                    value.required = 1
-                    value.typolink.parameter.current = 1
-                    value.typolink.parameter.rawUrlEncode = 1
-                    value.typolink.parameter.prepend = TEXT
-                    value.typolink.parameter.prepend.value = https://kxp.k10plus.de/DB=1.28/CMD?ACT=SRCHA&amp;IKT=8079&amp;TRM=
-                    value.wrap = &lt;dd&gt;[|]&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>5</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>50</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:1" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">1</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">26</field>
-                <field index="l18n_diffsource">a:2:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">4864</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Document Type</field>
-                <field index="index_name">type0</field>
-                <field index="format" type="integer">0</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt class=&quot;tx-dlf-type&quot;&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd class=&quot;tx-dlf-type&quot;&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>26</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:24" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">24</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386192</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">25</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5120</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Publication Run</field>
-                <field index="index_name">publicationRun0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.replacement.1.search = /(\s)/
-                    value.replacement.1.replace = $1-$1
-                    value.replacement.1.useRegExp = 1
-                    value.replacement.2.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
-                    value.replacement.2.replace = $3.$2.$1
-                    value.replacement.2.useRegExp = 1
-                    value.required = 1
-                    value.noTrimWrap = ||, |
-                    all.substring = 0,-2
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>25</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>36</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:22" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">22</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386673</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">23</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">1</field>
-                <field index="sorting" type="integer">5248</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Place of Publication (Parent)</field>
-                <field index="index_name">parentPlace0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>23</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>42</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:20" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">20</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386757</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">21</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5312</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Repository</field>
-                <field index="index_name">repository0</field>
-                <field index="format" type="integer">2</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>21</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>15</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="1" type="array">
-                            <id>40</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:18" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">18</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386766</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">19</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5344</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Shelfmark</field>
-                <field index="index_name">shelfmark0</field>
-                <field index="format" type="integer">2</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>19</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>18</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                        <element index="1" type="array">
-                            <id>44</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:16" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">16</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386781</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">17</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5360</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Volume</field>
-                <field index="index_name">volume0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.if.value.field = type
-                    value.if.equals = volume
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>17</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>39</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:14" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">14</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386823</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">15</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5368</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Issue</field>
-                <field index="index_name">issue0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.if.value.field = type
-                    value.if.equals = issue
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>15</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>37</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:12" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">12</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386847</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">13</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5372</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Material</field>
-                <field index="index_name">material0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>13</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>13</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:10" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">10</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386860</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">11</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5374</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Leaves Count</field>
-                <field index="index_name">leavesCount</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>11</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>14</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:8" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">8</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386874</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">9</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5375</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Physical Form</field>
-                <field index="index_name">format0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.if.value.field = format
-                    value.if.equals = x
-                    value.if.negate = 1
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>9</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>17</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:2" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">2</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386957</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">3</field>
-                <field index="l18n_diffsource">a:3:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:6:&quot;format&quot;;N;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5631</field>
-                <field index="l10n_state" type="NULL"></field>
-                <field index="label">Place of Publication</field>
-                <field index="index_name">place0</field>
-                <field index="format" type="integer">1</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.ifEmpty.field = parentPlace
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">1</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">1</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>3</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="format" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>16</id>
-                            <table>tx_dlf_metadataformat</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadata:39" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">39</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386039</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="sys_language_uid" type="integer">1</field>
-                <field index="l18n_parent" type="integer">40</field>
-                <field index="l18n_diffsource">a:15:{s:16:&quot;sys_language_uid&quot;;N;s:11:&quot;l18n_parent&quot;;N;s:4:&quot;wrap&quot;;s:64:&quot;key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;&quot;;s:10:&quot;index_name&quot;;s:4:&quot;year&quot;;s:6:&quot;format&quot;;i:0;s:15:&quot;index_tokenized&quot;;i:0;s:12:&quot;index_stored&quot;;i:0;s:13:&quot;index_indexed&quot;;i:1;s:11:&quot;index_boost&quot;;d:1;s:11:&quot;is_sortable&quot;;i:0;s:8:&quot;is_facet&quot;;i:0;s:9:&quot;is_listed&quot;;i:0;s:18:&quot;index_autocomplete&quot;;i:0;s:6:&quot;status&quot;;i:0;s:6:&quot;hidden&quot;;i:0;}</field>
-                <field index="hidden" type="integer">0</field>
-                <field index="sorting" type="integer">5888</field>
-                <field index="l10n_state">{&quot;wrap&quot;:&quot;parent&quot;}</field>
-                <field index="label">Year of Publication</field>
-                <field index="index_name">year0</field>
-                <field index="format" type="integer">0</field>
-                <field index="default_value"></field>
-                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
-                    value.required = 1
-                    value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
-                <field index="index_tokenized" type="integer">0</field>
-                <field index="index_stored" type="integer">0</field>
-                <field index="index_indexed" type="integer">1</field>
-                <field index="index_boost" type="double">1</field>
-                <field index="is_sortable" type="integer">0</field>
-                <field index="is_facet" type="integer">0</field>
-                <field index="is_listed" type="integer">0</field>
-                <field index="index_autocomplete" type="integer">0</field>
-                <field index="status" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="sys_language_uid" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>sys_language</table>
-                        </element>
-                    </relations>
-                </field>
-                <field index="l18n_parent" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>40</id>
-                            <table>tx_dlf_metadata</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:1" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">1</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">32</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:title</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:2" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">2</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">36</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:title/teihdr:persName[@role=&quot;author&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:3" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">3</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">42</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origDate</field>
-                <field index="xpath_sorting">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origDate/@when</field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:4" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">4</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">3</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origPlace</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:5" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">5</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">9</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">concat(./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:dimensions[@type=&quot;leaves&quot;]/teihdr:width,&quot;x&quot;,./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:dimensions[@type=&quot;leaves&quot;]/teihdr:height,./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:dimensions[@type=&quot;leaves&quot;]/@unit)</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:6" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">6</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">11</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:measure[@type=&quot;leavesCount&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:7" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">7</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">13</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:support</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:8" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">8</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">19</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:msIdentifier/teihdr:idno</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:9" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">9</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">21</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:msIdentifier/teihdr:repository</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:10" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">10</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">46</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:msIdentifier/teihdr:settlement</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:11" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">11</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">35</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:title/teihdr:persName[@role=&quot;author&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:12" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">12</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">45</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:msIdentifier/teihdr:settlement</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:13" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">13</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">12</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:support</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:14" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">14</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">10</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:measure[@type=&quot;leavesCount&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:15" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">15</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">20</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:msIdentifier/teihdr:repository</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:16" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">16</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">2</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origPlace</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:17" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">17</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">8</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">concat(./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:dimensions[@type=&quot;leaves&quot;]/teihdr:width,&quot;x&quot;,./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:dimensions[@type=&quot;leaves&quot;]/teihdr:height,./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:physDesc/teihdr:objectDesc/teihdr:supportDesc/teihdr:extent/teihdr:dimensions[@type=&quot;leaves&quot;]/@unit)</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:18" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">18</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">18</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:msIdentifier/teihdr:idno</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:19" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">19</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">31</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:title</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:20" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">20</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">41</field>
-                <field index="encoded" type="integer">1</field>
-                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origDate</field>
-                <field index="xpath_sorting">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origDate/@when</field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>1</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:21" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">21</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">28</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">//mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:22" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">22</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">30</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:nonSort,&quot; &quot;,./mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title)</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:23" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">23</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">32</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:nonSort,&quot; &quot;,./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title,&quot; &quot;,./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:partNumber,&quot; &quot;,./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:partName)</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:24" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">24</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">34</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;aut&quot;]/mods:displayForm</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:25" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">25</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">38</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@keyDate=&quot;yes&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:26" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">26</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">42</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[not(@point)]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:27" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">27</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">44</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[@point=&quot;end&quot;])</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:28" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">28</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">25</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@point=&quot;end&quot;])</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:29" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">29</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">23</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:place/mods:placeTerm</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:30" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">30</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">5</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:identifier[@type=&quot;vd17&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:31" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">31</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">7</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:identifier[@type=&quot;vd16&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:32" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">32</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">15</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:part/mods:detail/mods:number</field>
-                <field index="xpath_sorting">./mods:part[@type=&quot;host&quot;]/@order</field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:33" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">33</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">17</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:part/mods:detail/mods:number</field>
-                <field index="xpath_sorting">./mods:part[@type=&quot;host&quot;]/@order</field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:34" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">34</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">19</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:location/mods:shelfLocator</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:35" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">35</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">21</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:location/mods:physicalLocation</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:36" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">36</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">24</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@point=&quot;end&quot;])</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:37" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">37</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">14</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:part/mods:detail/mods:number</field>
-                <field index="xpath_sorting">./mods:part[@type=&quot;host&quot;]/@order</field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:38" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">38</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">33</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;aut&quot;]/mods:displayForm</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:39" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">39</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">16</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:part/mods:detail/mods:number</field>
-                <field index="xpath_sorting">./mods:part[@type=&quot;host&quot;]/@order</field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:40" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">40</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">20</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:location/mods:physicalLocation</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:42" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">42</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">22</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:place/mods:placeTerm</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:43" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">43</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">29</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:nonSort,&quot; &quot;,./mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title)</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:44" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">44</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">18</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:location/mods:shelfLocator</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:45" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">45</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">31</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:nonSort,&quot; &quot;,./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title,&quot; &quot;,./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:partNumber,&quot; &quot;,./mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:partName)</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:46" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">46</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">41</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[not(@point)]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:47" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">47</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">27</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">//mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:48" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">48</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">43</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[@point=&quot;end&quot;])</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:49" type="array">
-            <fieldlist index="data" type="array">
-                <field index="uid" type="integer">49</field>
-                <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
-                <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">6</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:identifier[@type=&quot;vd16&quot;]</field>
-                <field index="xpath_sorting"></field>
-                <field index="mandatory" type="integer">0</field>
-            </fieldlist>
-            <related index="rels" type="array">
-                <field index="encoded" type="array">
-                    <type>db</type>
-                    <relations index="itemArray" type="array">
-                        <element index="0" type="array">
-                            <id>2</id>
-                            <table>tx_dlf_formats</table>
-                        </element>
-                    </relations>
-                </field>
-            </related>
-        </tablerow>
-        <tablerow index="tx_dlf_metadataformat:50" type="array">
+        <tablerow index="tx_dlf_metadata:50" type="array">
             <fieldlist index="data" type="array">
                 <field index="uid" type="integer">50</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620333372</field>
-                <field index="crdate" type="integer">1620333372</field>
-                <field index="cruser_id" type="integer">2</field>
+                <field index="tstamp" type="integer">1752161762</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">4</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;index_tokenized&quot;:&quot;&quot;,&quot;index_stored&quot;:&quot;&quot;,&quot;index_indexed&quot;:&quot;&quot;,&quot;index_boost&quot;:&quot;&quot;,&quot;is_sortable&quot;:&quot;&quot;,&quot;is_facet&quot;:&quot;&quot;,&quot;is_listed&quot;:&quot;&quot;,&quot;index_autocomplete&quot;:&quot;&quot;,&quot;format&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;,&quot;hidden&quot;:&quot;&quot;,&quot;status&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2080</field>
+                <field index="label">Digitalisierung</field>
+                <field index="index_name">digitization</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;&lt;dl class=&quot;tx-dlf-metadata-subentry&quot;&gt;|&lt;/dl&gt;&lt;/dd&gt;
+                </field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">0</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">0</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>77</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:49" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">49</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2112</field>
+                <field index="label">gefördert durch</field>
+                <field index="index_name">funder</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>82</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:48" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">48</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2176</field>
+                <field index="label">digitale Bearbeitung Ton</field>
+                <field index="index_name">digital_processing</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>60</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadata:47" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">47</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;format&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2304</field>
+                <field index="label">verwendete Entzerrungskurve</field>
+                <field index="index_name">equalization_curve</field>
+                <field index="format" type="integer">1</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+                <field index="index_tokenized" type="integer">0</field>
+                <field index="index_stored" type="integer">1</field>
+                <field index="index_indexed" type="integer">1</field>
+                <field index="index_boost" type="double">1</field>
+                <field index="is_sortable" type="integer">0</field>
+                <field index="is_facet" type="integer">0</field>
+                <field index="is_listed" type="integer">1</field>
+                <field index="index_autocomplete" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="format" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>59</id>
+                            <table>tx_dlf_metadataformat</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:52" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">52</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">62</field>
                 <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:identifier[@type=&quot;vd17&quot;]</field>
+                <field index="xpath">./mods:accessCondition[@type=&quot;restriction on access&quot;]//@xlink:href</field>
                 <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:53" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">53</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:relatedItem[@type=&quot;otherVersion&quot;]/mods:titleInfo/mods.title</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
                 <field index="mandatory" type="integer">0</field>
             </fieldlist>
             <related index="rels" type="array">
@@ -8162,14 +6404,81 @@
             <fieldlist index="data" type="array">
                 <field index="uid" type="integer">54</field>
                 <field index="pid" type="integer">3</field>
-                <field index="tstamp" type="integer">1620386002</field>
-                <field index="crdate" type="integer">1620386002</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
                 <field index="cruser_id" type="integer">1</field>
                 <field index="deleted" type="integer">0</field>
-                <field index="parent_id" type="integer">37</field>
-                <field index="encoded" type="integer">2</field>
-                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@keyDate=&quot;yes&quot;]</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">58</field>
+                <field index="encoded" type="integer">7</field>
+                <field index="xpath">./audiomd:AUDIOMD</field>
                 <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">8</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>7</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+                <field index="subentries" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>51</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="1" type="array">
+                            <id>46</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="2" type="array">
+                            <id>42</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="3" type="array">
+                            <id>38</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="4" type="array">
+                            <id>35</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="5" type="array">
+                            <id>32</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="6" type="array">
+                            <id>29</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="7" type="array">
+                            <id>26</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:55" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">55</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">69</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:subject[@authority=&quot;gnd&quot;]/mods:geographic</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
                 <field index="mandatory" type="integer">0</field>
             </fieldlist>
             <related index="rels" type="array">
@@ -8179,6 +6488,2404 @@
                         <element index="0" type="array">
                             <id>2</id>
                             <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:56" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">56</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">70</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:subject[@authority=&quot;gnd&quot;]/mods:topic</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:57" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">57</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">71</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:abstract</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:58" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">58</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">84</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:relatedItem[@type=&quot;series&quot;]/mods:titleInfo/mods:title</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:59" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">59</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">47</field>
+                <field index="encoded" type="integer">7</field>
+                <field index="xpath">./audiomd:fileData/audiomd:otherUse</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>7</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:60" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">60</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">48</field>
+                <field index="encoded" type="integer">7</field>
+                <field index="xpath">./audiomd:audioInfo/audiomd:note</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>7</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:61" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">61</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">61</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:accessCondition/mods:rights.holder</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:62" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">62</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">63</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:accessCondition[@type=&quot;local terms of use&quot;]//@xlink:href</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:63" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">63</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">65</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:identifier[@type=&quot;swb-ppn-digital&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:64" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">64</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">66</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:identifier[@type=&quot;kxp&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:65" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">65</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">72</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;ive&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:66" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">66</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">85</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:titleInfo[@type=&quot;translated&quot;]/mods:title</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:67" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">67</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">73</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;cnd&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:68" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">68</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">80</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;fmk&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:69" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">69</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">81</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;fmd&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:70" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">70</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">74</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;prf&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">2</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+                <field index="subentries" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>52</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="1" type="array">
+                            <id>47</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:71" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">71</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">75</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;arr&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:72" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">72</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">64</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:accessCondition[@type=&quot;use and reproduction&quot;]//@xlink:href</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:73" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">73</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">67</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:identifier[@type=&quot;purl&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:74" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">74</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">55</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:identifier[@type=&quot;workCatalogue&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:75" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">75</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">77</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;dte&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:76" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">76</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">78</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;lbt&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:77" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">77</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161762</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">50</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;digitization&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">4</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+                <field index="subentries" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>54</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="1" type="array">
+                            <id>49</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="2" type="array">
+                            <id>44</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="3" type="array">
+                            <id>39</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:78" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">78</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">79</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;cmp&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:79" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">79</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">87</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:titleInfo[@type=&quot;uniform&quot;]/mods:title</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:80" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">80</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">68</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:genre</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:81" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">81</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">76</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;scr&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:82" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">82</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">49</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;fnd&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:83" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">83</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">60</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:relatedItem[@type=&quot;original&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">20</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+                <field index="subentries" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>53</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="1" type="array">
+                            <id>48</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="2" type="array">
+                            <id>43</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="3" type="array">
+                            <id>40</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="4" type="array">
+                            <id>36</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="5" type="array">
+                            <id>33</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="6" type="array">
+                            <id>30</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="7" type="array">
+                            <id>27</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="8" type="array">
+                            <id>24</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="9" type="array">
+                            <id>22</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="10" type="array">
+                            <id>20</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="11" type="array">
+                            <id>18</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="12" type="array">
+                            <id>16</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="13" type="array">
+                            <id>14</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="14" type="array">
+                            <id>12</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="15" type="array">
+                            <id>10</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="16" type="array">
+                            <id>8</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="17" type="array">
+                            <id>6</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="18" type="array">
+                            <id>4</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                        <element index="19" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_metadatasubentries</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:84" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">84</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">56</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:identifier[@type=&quot;rism&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:85" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">85</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">86</field>
+                <field index="encoded" type="integer">1</field>
+                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:title</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:86" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">86</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">82</field>
+                <field index="encoded" type="integer">1</field>
+                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:title/teihdr:persName[@role=&quot;author&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:87" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">87</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">38</field>
+                <field index="encoded" type="integer">1</field>
+                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origDate</field>
+                <field index="xpath_sorting">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origDate/@when</field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:88" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">88</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">18</field>
+                <field index="encoded" type="integer">1</field>
+                <field index="xpath">./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:history/teihdr:origin/teihdr:origPlace</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>1</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:89" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">89</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">57</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">//mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:90" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">90</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">32</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">concat(./mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:nonSort,&quot; &quot;,./mods:relatedItem[@type=&quot;host&quot;]/mods:titleInfo[not(@type=&quot;alternative&quot;)]/mods:title)</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:91" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">91</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">86</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:titleInfo[not(@type=&quot;uniform&quot;)]/mods:title</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:92" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">92</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">34</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:name[./mods:role/mods:roleTerm[@authority=&quot;marcrelator&quot;][@type=&quot;code&quot;]=&quot;aut&quot;]/mods:displayForm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:93" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">93</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">37</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@keyDate=&quot;yes&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:94" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">94</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">38</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[not(@point)]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:95" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">95</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">40</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateCreated[@point=&quot;end&quot;])</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:96" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">96</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">27</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:dateIssued[@point=&quot;end&quot;])</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:97" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">97</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">26</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:relatedItem[@type=&quot;host&quot;]/mods:originInfo[@eventType=&quot;production&quot; or @eventType=&quot;publication&quot; or not(./mods:edition=&quot;[Electronic ed.]&quot;)]/mods:place/mods:placeTerm</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:98" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">98</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">51</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:identifier[@type=&quot;vd17&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:99" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">99</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">52</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:identifier[@type=&quot;vd16&quot;]</field>
+                <field index="xpath_sorting"></field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:100" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">100</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">53</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:part/mods:detail/mods:number</field>
+                <field index="xpath_sorting">./mods:part[@type=&quot;host&quot;]/@order</field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadataformat:101" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">101</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="encoded" type="integer">2</field>
+                <field index="xpath">./mods:part/mods:detail/mods:number</field>
+                <field index="xpath_sorting">./mods:part[@type=&quot;host&quot;]/@order</field>
+                <field index="subentries" type="integer">0</field>
+                <field index="mandatory" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="encoded" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>2</id>
+                            <table>tx_dlf_formats</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:51" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">51</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Trägertyp</field>
+                <field index="index_name">carrier_type</field>
+                <field index="xpath">./audiomd:physicalData/audiomd:physFormat</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:52" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">52</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">70</field>
+                <field index="label">Name</field>
+                <field index="index_name">performer_displayName</field>
+                <field index="xpath">./mods:displayForm</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:53" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">53</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Vorlagetitel</field>
+                <field index="index_name">title_original</field>
+                <field index="xpath">./mods:titleInfo/mods:title</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:54" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">54</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161762</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">1</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">77</field>
+                <field index="label">digitalisiert in</field>
+                <field index="index_name">digitization_place_original</field>
+                <field index="xpath">./mods:place/mods:placeTerm</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:46" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">46</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Trägerformat</field>
+                <field index="index_name">carrier_format</field>
+                <field index="xpath">concat(./audiomd:physicalData/audiomd:dimensions/@gauge,&quot; &quot;,./audiomd:physicalData/audiomd:dimensions/@unit)</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:47" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">47</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">70</field>
+                <field index="label">Rolle</field>
+                <field index="index_name">performer_roleTerm</field>
+                <field index="xpath">./mods:role/mods:roleTerm[@type=&quot;text&quot;]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:48" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">48</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Ausgabe</field>
+                <field index="index_name">edition_original</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;production&quot;]/mods:edition</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:49" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">49</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161762</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">2</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">77</field>
+                <field index="label">digitalisiert am</field>
+                <field index="index_name">digitization_time_original</field>
+                <field index="xpath">./mods:dateCaptured</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.trim = 1
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:42" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">42</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">3</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Produktionsstufe</field>
+                <field index="index_name">production_level</field>
+                <field index="xpath">./audiomd:physicalData/audiomd:generation</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:43" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">43</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">3</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Besetzung</field>
+                <field index="index_name">perfres_original</field>
+                <field index="xpath">./mods:tableOfContents[@type=&quot;perfRes&quot;]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:44" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">44</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161762</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">3</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">77</field>
+                <field index="label">digitalisiert durch</field>
+                <field index="index_name">digitization_publisher_original</field>
+                <field index="xpath">./mods:publisher</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:38" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">38</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">4</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Abspielgeschwindigkeit</field>
+                <field index="index_name">playback_speed</field>
+                <field index="xpath">./audiomd:physicalData/audiomd:speed</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:39" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">39</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161762</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">4</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">77</field>
+                <field index="label">Digitalisat veröffentlicht</field>
+                <field index="index_name">digitization_issued</field>
+                <field index="xpath">./mods:dateIssued</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:40" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">40</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">4</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Einrichtung</field>
+                <field index="index_name">repository_original</field>
+                <field index="xpath">./mods:location/mods:physicalLocation</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:35" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">35</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">5</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Laufzeit</field>
+                <field index="index_name">duration_audio</field>
+                <field index="xpath">./audiomd:audioInfo/audiomd:duration</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:36" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">36</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">5</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Signatur</field>
+                <field index="index_name">shelfmark_original</field>
+                <field index="xpath">./mods:location/mods:shelfLocator</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:32" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">32</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">6</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Klangfeld</field>
+                <field index="index_name">soundfield_audio</field>
+                <field index="xpath">./audiomd:audioInfo/audiomd:soundField</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:33" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">33</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">6</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Ehem. Signatur</field>
+                <field index="index_name">shelfmark_invalid_original</field>
+                <field index="xpath">./mods:identifier[@type=&quot;shelfLocator&quot;][@invalid=&quot;yes&quot;]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:29" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">29</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">7</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Informationen zu Audiospuren</field>
+                <field index="index_name">information_audiotracks</field>
+                <field index="xpath">./audiomd:physicalData/audiomd:tracking/audiomd:trackingType</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:30" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">30</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">7</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Erscheinungsort</field>
+                <field index="index_name">place_publication_original</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;publication&quot;]/mods:place/mods:placeTerm</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:26" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">26</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752149427</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">8</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">54</field>
+                <field index="label">Zustandshinweis</field>
+                <field index="index_name">condition_audio</field>
+                <field index="xpath">./audiomd:physicalData/audiomd:condition</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:27" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">27</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">8</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Entstehungsort</field>
+                <field index="index_name">place_production_original</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;manufacture&quot;]/mods:place/mods:placeTerm</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:24" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">24</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">9</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Erscheinungsjahr</field>
+                <field index="index_name">time_publication_original</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;publication&quot;]/mods:dateIssued[@keyDate=&quot;yes&quot;][not(@point=&quot;start&quot;)][not(@point=&quot;end&quot;)]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:22" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">22</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">10</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Entstehungszeit</field>
+                <field index="index_name">date_production_original</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;production&quot;]/mods:dateCreated[@keyDate=&quot;yes&quot;][not(@point=&quot;start&quot;)][not(@point=&quot;end&quot;)]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:20" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">20</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">11</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Entstehungszeit (Verlauf)</field>
+                <field index="index_name">timespan_original</field>
+                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;production&quot;]/mods:dateCreated[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;production&quot;]/mods:dateCreated[@point=&quot;end&quot;])</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.trim = 1
+value.required = 1
+value.replacement.1.search = /(\s)/
+value.replacement.1.replace = $1-$1
+value.replacement.1.useRegExp = 1
+value.replacement.2.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
+value.replacement.2.replace = $3.$2.$1
+value.replacement.2.useRegExp = 1
+value.orderedStdWrap {
+                    10.noTrimWrap = ||, |
+                    20.substring = 0,-2
+                    }
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:18" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">18</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">12</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Erscheinungszeit (Verlauf)</field>
+                <field index="index_name">timespan_publication_original</field>
+                <field index="xpath">concat(./mods:originInfo[@eventType=&quot;publication&quot;]/mods:dateIssued[@point=&quot;start&quot;],&quot; &quot;,./mods:originInfo[@eventType=&quot;publication&quot;]/mods:dateIssued[@point=&quot;end&quot;])</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.trim = 1
+value.required = 1
+value.replacement.1.search = /(\s)/
+value.replacement.1.replace = $1-$1
+value.replacement.1.useRegExp = 1
+value.replacement.2.search = /([0-9]{4})-([0-1]?[0-9])-([0-3]?[0-9])/
+value.replacement.2.replace = $3.$2.$1
+value.replacement.2.useRegExp = 1
+value.orderedStdWrap {
+                    10.noTrimWrap = ||, |
+                    20.substring = 0,-2
+                    }
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:16" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">16</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">13</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Umfang</field>
+                <field index="index_name">physical_extent_original</field>
+                <field index="xpath">./mods:physicalDescription/mods:extent[not(@unit)]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:14" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">14</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">14</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Format</field>
+                <field index="index_name">physical_format_orig</field>
+                <field index="xpath">concat(./mods:physicalDescription/mods:extent[@unit],&quot; &quot;,./mods:physicalDescription/mods:extent/@unit)</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:12" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">12</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">15</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Sprache</field>
+                <field index="index_name">language_original</field>
+                <field index="xpath">./mods:language/mods:languageTerm[@authority=&quot;rfc3066&quot;]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:10" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">10</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">16</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Notation</field>
+                <field index="index_name">notation_original</field>
+                <field index="xpath">./mods:language/mods:scriptTerm</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:8" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">8</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">17</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Plattennummer</field>
+                <field index="index_name">identifier_platenumber</field>
+                <field index="xpath">./mods:identifier[@type=&quot;plateNumber&quot;][@invalid=&quot;yes&quot;]</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:6" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">6</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">18</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Verlag</field>
+                <field index="index_name">publisher_original</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;publication&quot;]/mods:publisher</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:4" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">4</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">19</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Ausgabe</field>
+                <field index="index_name">edition_original_print</field>
+                <field index="xpath">./mods:originInfo[@eventType=&quot;publication&quot;]/mods:edition</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_metadatasubentries:2" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">2</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1752161824</field>
+                <field index="crdate" type="integer">1752149427</field>
+                <field index="cruser_id" type="integer">1</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">{&quot;label&quot;:&quot;&quot;,&quot;index_name&quot;:&quot;&quot;,&quot;xpath&quot;:&quot;&quot;,&quot;default_value&quot;:&quot;&quot;,&quot;wrap&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;,&quot;sys_language_uid&quot;:&quot;&quot;}</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="sorting" type="integer">20</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="parent_id" type="integer">83</field>
+                <field index="label">Anmerkung</field>
+                <field index="index_name">note</field>
+                <field index="xpath">./mods:note</field>
+                <field index="default_value"></field>
+                <field index="wrap">key.wrap = &lt;dt&gt;|&lt;/dt&gt;
+value.required = 1
+value.wrap = &lt;dd&gt;|&lt;/dd&gt;</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_structures:181" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">181</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
+                <field index="cruser_id" type="integer">2</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l18n_diffsource">a:7:{s:8:&quot;toplevel&quot;;N;s:5:&quot;label&quot;;N;s:10:&quot;index_name&quot;;N;s:8:&quot;oai_name&quot;;N;s:16:&quot;sys_language_uid&quot;;N;s:6:&quot;hidden&quot;;N;s:6:&quot;status&quot;;N;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="toplevel" type="integer">0</field>
+                <field index="label">Abschnitt</field>
+                <field index="index_name">section</field>
+                <field index="oai_name"></field>
+                <field index="thumbnail" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tx_dlf_structures:180" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">180</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
+                <field index="cruser_id" type="integer">2</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">177</field>
+                <field index="l18n_diffsource">{&quot;sys_language_uid&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="toplevel" type="integer">1</field>
+                <field index="label">Act</field>
+                <field index="index_name">act0</field>
+                <field index="oai_name"></field>
+                <field index="thumbnail" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="l18n_parent" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>177</id>
+                            <table>tx_dlf_structures</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_structures:179" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">179</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
+                <field index="cruser_id" type="integer">2</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">161</field>
+                <field index="l18n_diffsource">{&quot;sys_language_uid&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="toplevel" type="integer">0</field>
+                <field index="label">Additional</field>
+                <field index="index_name">additional0</field>
+                <field index="oai_name"></field>
+                <field index="thumbnail" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="l18n_parent" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>161</id>
+                            <table>tx_dlf_structures</table>
+                        </element>
+                    </relations>
+                </field>
+            </related>
+        </tablerow>
+        <tablerow index="tx_dlf_structures:178" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">178</field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1750409083</field>
+                <field index="crdate" type="integer">1750409083</field>
+                <field index="cruser_id" type="integer">2</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">171</field>
+                <field index="l18n_diffsource">{&quot;sys_language_uid&quot;:&quot;&quot;,&quot;l18n_parent&quot;:&quot;&quot;}</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="hidden" type="integer">0</field>
+                <field index="toplevel" type="integer">0</field>
+                <field index="label">Address</field>
+                <field index="index_name">address0</field>
+                <field index="oai_name"></field>
+                <field index="thumbnail" type="integer">0</field>
+                <field index="status" type="integer">0</field>
+            </fieldlist>
+            <related index="rels" type="array">
+                <field index="l18n_parent" type="array">
+                    <type>db</type>
+                    <relations index="itemArray" type="array">
+                        <element index="0" type="array">
+                            <id>171</id>
+                            <table>tx_dlf_structures</table>
                         </element>
                     </relations>
                 </field>


### PR DESCRIPTION
- Update of tables `tx_dlf_formats`, `tx_dlf_metadata`, `tx_dlf_metadataformat` and `tx_dlf_metadatasubentries`

### Example

`https://.../viewer/?tx_dlf%5Bid%5D=https%3A%2F%2Fgit.uni-paderborn.de%2Fapi%2Fv4%2Fprojects%2F3852%2Frepository%2Ffiles%2FMETS_MODS%252Fmets_M0001.xml%2Fraw&no_cache=1`

#### Original data of testsystem: 

<img width="1918" height="1083" alt="image" src="https://github.com/user-attachments/assets/981cfde0-28a2-499e-89f3-a3cd59ef0761" />

#### TYPO3 11

<img width="1914" height="1002" alt="image" src="https://github.com/user-attachments/assets/6c9d63dd-a76e-4d38-8dc8-89949e0a3bcc" />

#### TYPO3 12

<img width="1918" height="1083" alt="image" src="https://github.com/user-attachments/assets/52bac713-de93-41e8-a68e-c15c0c28aa71" />


> [!NOTE]  
> The difference in the number under "Angaben zum Original" is due to the feature that the source code does not output the empty metadata fields.