### PR TITLE
[BUGFIX] Remove hardcoded CSS for navigation

### DIFF
--- a/Resources/Public/Css/annotationStyles.css
+++ b/Resources/Public/Css/annotationStyles.css
@@ -71,16 +71,6 @@ rect.active {
     z-index: 9;
 }
 
-.tx-dlf-navigation-next {
-    position: absolute;
-    top: 40px;
-}
-
-.tx-dlf-navigation-prev {
-    position: absolute;
-    top: 20px;
-}
-
 .sync-views {
     display: none;
 }


### PR DESCRIPTION
It was overriding specific css for navigation buttons.

Fixes one of the problems described in #477 