### PR TITLE
[BUGFIX] Add template for fulltext container

### DIFF
--- a/Resources/Private/Plugins/Kitodo/Partials/PageView/FulltextContainer.html
+++ b/Resources/Private/Plugins/Kitodo/Partials/PageView/FulltextContainer.html
@@ -1,0 +1,18 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<div class="tx-dlf-toolbox-fulltext-container">
+    <div id="tx-dlf-toolbox-fulltext-selection"></div>
+</div>
+
+</html>


### PR DESCRIPTION
It used template from slub_digitalcollections, but now that template throws error becuase of missing TS config.