### PR TITLE
[MAINTEANCE] Refactor calendar view identification

### DIFF
--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -500,10 +500,10 @@ page.10.variables {
 # 3D object
 # --------------------------------------------------------------------------------------------------------------------
 [getDocumentType({$plugin.tx_dlf.persistence.storagePid}) == "object"]
-    page.10.variables {
-        is3dObject = TEXT
-        is3dObject.value = 1
-    }
+page.10.variables {
+    is3dObject = TEXT
+    is3dObject.value = 1
+}
 [END]
 
 # --------------------------------------------------------------------------------------------------------------------
@@ -511,21 +511,18 @@ page.10.variables {
 # --------------------------------------------------------------------------------------------------------------------
 [getDocumentType({$plugin.tx_dlf.persistence.storagePid}) == "ephemera" or getDocumentType({$plugin.tx_dlf.persistence.storagePid}) == "newspaper"]
 page.10.variables {
-  isNewspaper = TEXT
-  isNewspaper.value = newspaper_anchor
+    isCalendar = TEXT
+    isCalendar.value = 1
+    isCalendarType = TEXT
+    isCalendarType.value = anchor
 }
 [END]
 
 [getDocumentType({$plugin.tx_dlf.persistence.storagePid}) == "year"]
 page.10.variables {
-  isNewspaper = TEXT
-  isNewspaper.value = newspaper_year
-}
-[END]
-
-[getDocumentType({$plugin.tx_dlf.persistence.storagePid}) == "issue"]
-page.10.variables {
-  isNewspaper = TEXT
-  isNewspaper.value = newspaper_issue
+    isCalendar = TEXT
+    isCalendar.value = 1
+    isCalendarType = TEXT
+    isCalendarType.value = year
 }
 [END]

--- a/Resources/Private/Layouts/KitodoPage.html
+++ b/Resources/Private/Layouts/KitodoPage.html
@@ -17,7 +17,7 @@
         <f:else if="{is3dObject} == 1">
             <f:render section="ModelView" partial="Kitodo/View/ModelView" arguments="{_all}" />
         </f:else>
-        <f:else if="{isNewspaper} == 'newspaper_anchor' OR {isNewspaper} == 'newspaper_year'">
+        <f:else if="{isCalendar} == 1">
             <f:render section="CalendarView" partial="Kitodo/View/CalendarView" arguments="{_all}" />
         </f:else>
         <f:else>

--- a/Resources/Private/Partials/Kitodo/DocumentFunctions.html
+++ b/Resources/Private/Partials/Kitodo/DocumentFunctions.html
@@ -23,7 +23,7 @@
 
     <div class="document-functions">
         <f:render partial="Kitodo/DocumentFunctions/Provider" arguments="{_all}"/>
-        <f:if condition="{isNewspaper} == 'newspaper_anchor' OR {isNewspaper} == 'newspaper_year'">
+        <f:if condition="{isCalendar} == 1">
             <f:else>
                 <f:render partial="Kitodo/DocumentFunctions/Submenu" arguments="{_all}"/>
             </f:else>

--- a/Resources/Private/Partials/Kitodo/View/CalendarView.html
+++ b/Resources/Private/Partials/Kitodo/View/CalendarView.html
@@ -18,12 +18,12 @@
     <div class="document-view">
         <f:render section="DocumentFunctions" partial="Kitodo/DocumentFunctions" arguments="{_all}"/>
 
-        <f:if condition="{isNewspaper} == 'newspaper_anchor'">
+        <f:if condition="{isCalendarType} == 'anchor'">
             <f:then>
                 <f:cObject typoscriptObjectPath="plugin.tx_dfgviewer_newspaperyears" />
             </f:then>
             <f:else>
-                <f:if condition="{isNewspaper} == 'newspaper_year'">
+                <f:if condition="{isCalendarType} == 'year'">
                     <f:cObject typoscriptObjectPath="plugin.tx_dfgviewer_newspapercalendar" />
                 </f:if>
             </f:else>


### PR DESCRIPTION
Replaces the overloaded `isNewspaper` variable with explicit `isCalendar` and `isCalendarType` variables. This clarifies the logic for rendering different calendar views in TypoScript and Fluid templates, making the conditions more readable and maintainable.