### PR TITLE
[BUGFIX] Rewrite handling legacy URL parameter mapping to middleware

### DIFF
--- a/Classes/Middleware/SetLegacyParametersMiddleware.php
+++ b/Classes/Middleware/SetLegacyParametersMiddleware.php
@@ -1,0 +1,70 @@
+<?php
+namespace Slub\Dfgviewer\Middleware;
+
+/**
+ * Copyright notice
+ *
+ * (c) Saxon State and University Library Dresden <typo3@slub-dresden.de>
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Plugin 'DFG-Viewer: Set Legacy Parameters Middleware for the 'dfgviewer' extension.
+ *
+ * @package TYPO3
+ * @subpackage tx_dfgviewer
+ * @access public
+ */
+class SetLegacyParametersMiddleware implements MiddlewareInterface
+{
+    /**
+     * The process method of the middleware.
+     *
+     * @access public
+     *
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     *
+     * @return ResponseInterface JSON response of search suggestions
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $parameters = $request->getQueryParams();
+        $setParameters = ($parameters['set'] ?? []);
+        if (!empty($setParameters)) {
+            if (isset($setParameters['mets'])) {
+                $parameters['tx_dlf']['id'] = $setParameters['mets'];
+            }
+            if (isset($setParameters['image'])) {
+                $parameters['tx_dlf']['page'] = $setParameters['image'];
+            }
+            if (isset($setParameters['double'])) {
+                $parameters['tx_dlf']['double'] = $setParameters['double'];
+            }
+            $request = $request->withQueryParams($parameters);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -30,6 +30,12 @@ return [
             'after' => [
                 'typo3/cms-frontend/prepare-tsfe-rendering'
             ]
+        ],
+        'dfgviewer/set-legacy-parameters' => [
+            'target' => Slub\Dfgviewer\Middleware\SetLegacyParametersMiddleware::class,
+            'after' => [
+                'typo3/cms-frontend/prepare-tsfe-rendering'
+            ],
         ]
     ],
 ];

--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -1,23 +1,3 @@
-# ------------------------------------
-# Map GET parameter set[] --> tx_dlf[]
-# ------------------------------------
-
-# map set[mets] --> tx_dlf[id]
-[like(traverse(request.getQueryParams(), 'set/mets'), 'http*')]
-plugin.tx_dlf._DEFAULT_PI_VARS.id.stdWrap.data = GP:set|mets
-[END]
-
-# map set[image] --> tx_dlf[page]
-[traverse(request.getQueryParams(), 'set/image')]
-plugin.tx_dlf._DEFAULT_PI_VARS.page.stdWrap.data = GP:set|image
-[END]
-
-# map set[double] --> tx_dlf[double]
-[traverse(request.getQueryParams(), 'set/double') > 0]
-plugin.tx_dlf._DEFAULT_PI_VARS.double.stdWrap.data = GP:set|double
-[END]
-
-
 # --------------------------------------------------------------------------------------------------------------------
 # Plugin configuration
 # --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Moves the mapping of `set` parameters (e.g., `set[mets]` to `tx_dlf[id]`) from conditional TypoScript to a dedicated PSR-15 middleware. This modernizes the implementation and aligns with current TYPO3 best practices for request manipulation.