### PR TITLE
[MAINTENANCE] Migrate ViewHelpers to instance-based render method

### DIFF
--- a/Classes/ViewHelpers/CalendarDataVariableViewHelper.php
+++ b/Classes/ViewHelpers/CalendarDataVariableViewHelper.php
@@ -25,7 +25,6 @@ namespace Slub\Dfgviewer\ViewHelpers;
  * This copyright notice MUST APPEAR in all copies of the script!
  */
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -46,23 +45,16 @@ class CalendarDataVariableViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     *
      * @return void
      */
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
-    ) {
-        $data = $arguments['data'];
+    public function render()
+    {
+        $data = $this->arguments['data'];
 
         if (count($data) === 12) {
             // Rule 1: If it's a single year (no season split), do show all the months
             // The condition works because showEmptyMonths = 1 in plugin configuration
-            $renderingContext->getVariableProvider()->add($arguments['name'], $data);
+            $this->renderingContext->getVariableProvider()->add($this->arguments['name'], $data);
         } else {
             $firstUsedIdx = 0;
             $lastUsedIdx = 0;
@@ -111,7 +103,7 @@ class CalendarDataVariableViewHelper extends AbstractViewHelper
                 $selectedData[$key] = $data[$key];
             }
 
-            $renderingContext->getVariableProvider()->add($arguments['name'], $selectedData);
+            $this->renderingContext->getVariableProvider()->add($this->arguments['name'], $selectedData);
         }
     }
 }

--- a/Classes/ViewHelpers/TitleTagViewHelper.php
+++ b/Classes/ViewHelpers/TitleTagViewHelper.php
@@ -24,8 +24,6 @@ namespace Slub\Dfgviewer\ViewHelpers;
  * This copyright notice MUST APPEAR in all copies of the script!
  */
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -44,31 +42,21 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class TitleTagViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * Initialize arguments.
      */
     public function initializeArguments()
     {
-        parent::initializeArguments();
-        $this->registerArgument('title', 'string', 'new page title', true);
+        $this->registerArgument('title', 'string', 'New page title', true);
     }
 
     /**
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
+     * Set the page title in the current frontend context.
      */
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
-      ) {
-        $title = $arguments['title'];
-
-        if ($title !== null) {
-            $GLOBALS['TSFE']->page['title'] = $title;
+    public function render()
+    {
+        if ($this->arguments['title'] !== null) {
+            $GLOBALS['TSFE']->page['title'] = $this->arguments['title'];
         }
     }
 }


### PR DESCRIPTION
Migration for:

```
TYPO3 Deprecation Notice: renderStatic() has been deprecated and will be removed in Fluid v5. in /var/www/html/vendor/typo3fluid/fluid/src/Core/ViewHelper/AbstractViewHelper.php line 518 
TYPO3 Deprecation Notice: CompileWithRenderStatic has been deprecated and will be removed in Fluid v5. in /var/www/html/vendor/typo3fluid/fluid/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php line 31 
```