### PR TITLE
[BUGFIX] Use correct labels for unavailable email

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -25,6 +25,10 @@
 				<source><![CDATA[Show in local context]]></source>
 				<target><![CDATA[Lokale Präsentation anzeigen]]></target>
 			</trans-unit>
+            <trans-unit id="provider.no_email_provider" approved="yes">
+                <source><![CDATA[No email provider available]]></source>
+                <target><![CDATA[Kein Email-Provider verfügbar]]></target>
+            </trans-unit>
 			<trans-unit id="provider.no_local_presentation" approved="yes">
 				<source><![CDATA[No local presentation available]]></source>
 				<target><![CDATA[Keine lokale Präsentation verfügbar]]></target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -23,6 +23,9 @@
             <trans-unit id="provider.local_presentation">
                 <source>Show in local context</source>
             </trans-unit>
+            <trans-unit id="provider.no_email_provider">
+                <source>No email provider available</source>
+            </trans-unit>
             <trans-unit id="provider.no_local_presentation">
                 <source>No local presentation available</source>
             </trans-unit>

--- a/Resources/Private/Partials/Kitodo/DocumentFunctions/Submenu/Links.html
+++ b/Resources/Private/Partials/Kitodo/DocumentFunctions/Submenu/Links.html
@@ -20,32 +20,31 @@
     <ul>
         <li>
             <f:variable name="presentationXpath"><dc:xpath xpath='({dvLinksXpath}/dv:presentation)[1]' htmlspecialchars='FALSE' /></f:variable>
-            <f:variable name="providerLocalPresentation"><f:translate key='provider.local_presentation' extensionName='dfgviewer' /></f:variable>
             <f:if condition="{presentationXpath}">
                 <f:then>
+                    <f:variable name="providerLocalPresentation"><f:translate key='provider.local_presentation' extensionName='dfgviewer' /></f:variable>
                     <f:link.external uri="{presentationXpath}" class="local-presentation" title="{providerLocalPresentation}">{providerLocalPresentation}</f:link.external>
                 </f:then>
                 <f:else>
-                    <span class="local-presentation" title="{providerLocalPresentation}">{providerLocalPresentation}</span>
+                    <f:variable name="providerNoLocalPresentation"><f:translate key='provider.no_local_presentation' extensionName='dfgviewer' /></f:variable>
+                    <span class="local-presentation" title="{providerNoLocalPresentation}">{providerNoLocalPresentation}</span>
                 </f:else>
             </f:if>
         </li>
         <f:render partial="Kitodo/DocumentFunctions/Submenu/ReferenceLinks" arguments="{_all}" />
-        <f:variable name="ownerContactXpath"><dc:xpath xpath='({dvRightsXpath}ownerContact)[1]' htmlspecialchars='FALSE' /></f:variable>
-        <f:variable name="providerEmailProvider"><f:translate key='provider.email_provider' extensionName='dfgviewer' /></f:variable>
-        <f:if condition="{ownerContactXpath}">
-            <f:then>
-                <li>
+        <li>
+            <f:variable name="ownerContactXpath"><dc:xpath xpath='({dvRightsXpath}ownerContact)[1]' htmlspecialchars='FALSE' /></f:variable>
+            <f:if condition="{ownerContactXpath}">
+                <f:then>
+                    <f:variable name="providerEmailProvider"><f:translate key='provider.email_provider' extensionName='dfgviewer' /></f:variable>
                     <f:link.external uri="{ownerContactXpath}" class="local-contact" title="{providerEmailProvider} ({dc:xpath(xpath:'({dvRightsXpath}owner)[1]')})">{providerEmailProvider}</f:link.external>
-                </li>
-            </f:then>
-            <f:else>
-                <f:variable name="providerNoLocalPresentation"><f:translate key='provider.no_local_presentation' extensionName='dfgviewer' /></f:variable>
-                <li>
-                    <span class="local-contact" title="{providerNoLocalPresentation}">{providerNoLocalPresentation}</span>
-                </li>
-            </f:else>
-        </f:if>
+                </f:then>
+                <f:else>
+                    <f:variable name="providerNoEmailProvider"><f:translate key='provider.no_email_provider' extensionName='dfgviewer' /></f:variable>
+                    <span class="local-contact" title="{providerNoEmailProvider}">{providerNoEmailProvider}</span>
+                </f:else>
+            </f:if>
+        </li>
         <f:cObject typoscriptObjectPath="plugin.tx_dfgviewer_uri" />
     </ul>
 </li>


### PR DESCRIPTION
Adds the `provider.no_email_provider` translation key. Ensures that when no local presentation or email contact is available, a specific 'no provider' message is displayed.