### PR TITLE
[FEATURE] Extend multivolume work detection to periodicals and inventories

### DIFF
--- a/Configuration/TypoScript/Plugins/kitodo.typoscript
+++ b/Configuration/TypoScript/Plugins/kitodo.typoscript
@@ -510,7 +510,7 @@ page.10.variables {
 # --------------------------------------------------------------------------------------------------------------------
 # Multivolume work
 # --------------------------------------------------------------------------------------------------------------------
-[getDocumentType({$plugin.tx_dlf.persistence.storagePid}) === 'multivolume_work']
+[getDocumentType({$plugin.tx_dlf.persistence.storagePid}) in ['multivolume_work','periodical','inventory']]
 page.10.variables {
   isMultivolumeWork = TEXT
   isMultivolumeWork.value = 1


### PR DESCRIPTION
The `isMultivolumeWork` flag now also applies to 'periodical' and 'inventory' document types, ensuring consistent handling for structured works that share similar characteristics.